### PR TITLE
support custom image in cycle templates

### DIFF
--- a/deployhpc.tpl.yml
+++ b/deployhpc.tpl.yml
@@ -37,11 +37,10 @@ queues:
     vm_size: Standard_HB120rs_v2
     max_core_count: 1024
     image: OpenLogic:CentOS-HPC:7.7:latest
-
-  # - name: viz3d
-  #   vm_size: Standard_NV6
-  #   image: centos-7.7-desktop-3d
-  #   max_core_count: 1000
+  - name: viz3d
+    vm_size: Standard_NV6
+    max_core_count: 1024
+    image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/images/centos-7.7-desktop-3d
   # - name: compute
   #   vm_size: Standard_HB120rs_v2
   #   image: centos-77-v1-rdma-gpgpu

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -11,7 +11,7 @@ spn_file=spn.json
 
 if [ -z "$ARM_CLIENT_ID" ]; then
   # Need the SPN name to use
-  spn_appname=$(jq -r '.spn_appname' $spn_file )
+  spn_appname=$(jq -r '.spn_name' $spn_file )
   echo "spn_appname=$spn_appname"
   # Need keyvault name where the SPN secret is stored
   key_vault=$(jq -r '.key_vault' $spn_file )

--- a/packer/centos-7.7-desktop-3d.json
+++ b/packer/centos-7.7-desktop-3d.json
@@ -13,7 +13,7 @@
             "managed_image_resource_group_name": "{{user `var_resource_group`}}",
             "managed_image_name": "{{user `var_image`}}",
             "os_type": "Linux",
-            "vm_size": "Standard_NV6_Promo",
+            "vm_size": "Standard_NV6",
             "ssh_pty": "true",
             "build_resource_group_name": "{{user `var_resource_group`}}"
         }

--- a/packer/centos77-v1-rdma-gpgpu.json
+++ b/packer/centos77-v1-rdma-gpgpu.json
@@ -11,7 +11,7 @@
             "image_sku": "7.7",
             "image_version": "7.7.2020062400",
             "managed_image_resource_group_name": "{{user `var_resource_group`}}",
-            "managed_image_name": "centos77-v1-rdma-gpgpu",
+            "managed_image_name": "{{user `var_image`}}",
             "os_type": "Linux",
             "vm_size": "Standard_d8s_v3",
             "ssh_pty": "true",

--- a/packer/centos77-v2-rdma-gpgpu.json
+++ b/packer/centos77-v2-rdma-gpgpu.json
@@ -11,7 +11,7 @@
             "image_sku": "7_7-gen2",
             "image_version": "7.7.2020111301",
             "managed_image_resource_group_name": "{{user `var_resource_group`}}",
-            "managed_image_name": "centos77-v2-rdma-gpgpu",
+            "managed_image_name": "{{user `var_image`}}",
             "os_type": "Linux",
             "vm_size": "Standard_d8s_v3",
             "ssh_pty": "true",

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -31,6 +31,7 @@ resource "local_file" "global_variables" {
       anf-home-ip         = element(azurerm_netapp_volume.home.mount_ip_addresses, 0)
       anf-home-path       = azurerm_netapp_volume.home.volume_path
       ondemand-fqdn       = azurerm_public_ip.ondemand-pip.fqdn
+      subscription_id     = data.azurerm_subscription.primary.subscription_id
     }
   )
   filename = "${local.playbook_root_dir}/group_vars/all.yml"
@@ -57,7 +58,6 @@ resource "local_file" "packer" {
   )
   filename = "${local.packer_root_dir}/options.json"
 }
-
 
 output "ondemand_fqdn" {
   value = azurerm_public_ip.ondemand-pip.fqdn

--- a/tf/templates/global_variables.tmpl
+++ b/tf/templates/global_variables.tmpl
@@ -10,4 +10,4 @@ anf_home_ip                   : ${ anf-home-ip }
 anf_home_path                 : ${ anf-home-path }
 ondemand_fqdn                 : ${ ondemand-fqdn }
 ansible_ssh_private_key_file  : ${admin_username}_id_rsa
-homedir_mountpoint            : ${homedir_mountpoint}
+subscription_id               : ${subscription_id}


### PR DESCRIPTION
- custom image ID can be specified using ansible variable substitution in the deployhpc.yml file
- fix bug when retrieving SPN name in build_image.sh
- use image variable name in packer files
- added subscription_id in global variables