### PR TITLE
Added codeserver interactive app

### DIFF
--- a/playbooks/ood-overrides.yml
+++ b/playbooks/ood-overrides.yml
@@ -21,6 +21,11 @@ clusters:
             export PATH="/opt/TurboVNC/bin:$PATH"
             export WEBSOCKIFY_CMD="/usr/bin/websockify"
             %s
+ood_install_apps:
+  codeserver:
+    repo: https://github.com/edwardsp/bc_osc_codeserver.git
+    dest: "{{ ood_sys_app_dir }}"
+    version: master
 ood_apps:
   bc_desktop:
     title: "remote desktop"


### PR DESCRIPTION
This is using a fork of the bc_osc_codeserver interative app and has been updated for options for az-hop.