### PR TITLE
create a vnet peering if specified in the same subscription

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -7,6 +7,11 @@ homedir_mountpoint: /anfhome
 admin_user: hpcadmin
 # Object ID to grant key vault read access
 key_vault_readers: <object_id>
+# Network
+network:
+  peering: # This is optional, and can be used to create a VNet Peering in the same subscription.
+    vnet_name: "VNET Name to Peer to"
+    vnet_resource_group: "Resource Group of the VNET to peer to"
 ad:
   vm_size: Standard_D2s_v3
 ondemand:

--- a/tf/network_peering.tf
+++ b/tf/network_peering.tf
@@ -1,0 +1,27 @@
+# Retrieve the peernetwork
+# If count is 0 the variables for name and resource group are not set, so setting fake values, but as count is 0 this won't be executed
+data "azurerm_virtual_network" "peernetwork" {
+  count               = local.create_peering
+  resource_group_name = local.create_peering == 1 ? local.peering_vnet_resource_group : "empty"
+  name                = local.create_peering == 1 ? local.peering_vnet_name : "empty"
+}
+
+resource "azurerm_virtual_network_peering" "azhop-to-peer" {
+  count                         = local.create_peering
+  name                          = "azhop-to-peer"
+  resource_group_name           = azurerm_resource_group.rg.name
+  virtual_network_name          = azurerm_virtual_network.azhop.name
+  remote_virtual_network_id     = data.azurerm_virtual_network.peernetwork[count.index].id
+  allow_virtual_network_access  = true
+  allow_forwarded_traffic       = true
+}
+
+resource "azurerm_virtual_network_peering" "peer-to-azhop" {
+  count                         = local.create_peering
+  name                          = "peer-to-azhop"
+  resource_group_name           = data.azurerm_virtual_network.peernetwork[count.index].resource_group_name
+  virtual_network_name          = data.azurerm_virtual_network.peernetwork[count.index].name
+  remote_virtual_network_id     = azurerm_virtual_network.azhop.id
+  allow_virtual_network_access  = true
+  allow_forwarded_traffic       = true
+}

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -19,4 +19,9 @@ locals {
     lustre_mds_sku = try(local.configuration_yml["lustre"]["mds_sku"], "Standard_D8d_v4")
     lustre_oss_sku = try(local.configuration_yml["lustre"]["oss_sku"], "Standard_D32d_v4")
     lustre_oss_count = try(local.configuration_yml["lustre"]["oss_count"], 2)
+
+    create_peering = try(length(local.peering_vnet_name) > 0 ? 1 : 0, 0)
+    peering_vnet_name = try(local.configuration_yml["network"]["peering"]["vnet_name"], null)
+    peering_vnet_resource_group = try(local.configuration_yml["network"]["peering"]["vnet_resource_group"], null)
+
 }


### PR DESCRIPTION
add optional VNET Peering parameters in the configuration file
```yml
network:
  peering:
    vnet_name: "vnet name to peer to"
    vnet_resource_group: "resource group of the vnet to peer to"
```
This only works if the peered vnet is in the same subscription and if the address space is not in conflict
close #346 
