### PR TITLE
support spot instance with spot_price=-1

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -76,11 +76,17 @@ images:
     os_type: Linux # Linux or Windows
     version: 7.8 # Version of the image to create the image definition in SIG
 queues:
-  - name: execute
+  - name: execute # name of the Cycle Cloud node array
+    # Azure VM Instance type
     vm_size: Standard_F2s_v2
+    # maximum number of cores that can be instanciated
     max_core_count: 1024
+    # marketplace image name or custom image id
     image: OpenLogic:CentOS-HPC:7.7:latest
-    #EnableAcceleratedNetworking: true or false # false is the default value
+    # Set to true if AccelNet need to be enabled. false is the default value
+    EnableAcceleratedNetworking: false
+    # spot instance support. Default is false
+    spot: true
   - name: hc44rs
     vm_size: Standard_HC44rs
     max_core_count: 1024

--- a/playbooks/roles/cyclecloud_pbs/templates/pbs-headless.txt.j2
+++ b/playbooks/roles/cyclecloud_pbs/templates/pbs-headless.txt.j2
@@ -17,6 +17,7 @@ Autoscale = true
     Region = {{ cc_region }}
     KeyPairLocation = ~/.ssh/cyclecloud.pem
     EnableAcceleratedNetworking = false
+    Interruptible = false
 
         [[[configuration]]]
         keepalive.timeout = 1800 # The amount of time in seconds to keep a node "alive" if it has not finished installing/configuring software.
@@ -42,10 +43,12 @@ Autoscale = true
     [[nodearray {{ queue.name }}]]
     MachineType = {{ queue.vm_size }} 
     MaxCoreCount = {{ queue.max_core_count }}
-  {% if queue.EnableAcceleratedNetworking is defined %}        
+  {% if queue.EnableAcceleratedNetworking is defined %}
     EnableAcceleratedNetworking = {{ queue.EnableAcceleratedNetworking }}
   {% endif %}
-    Interruptible = false
+  {% if queue.spot is defined %}
+    Interruptible = {{queue.spot}}
+  {% endif %}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}


### PR DESCRIPTION
- added a spot=true/false in the queue options
- map to Interruptible = true / false in the Cycle template (false is the default)

close #251 