### PR TITLE
set OS disk to be StandardSSD_LRS

### DIFF
--- a/playbooks/roles/cyclecloud_pbs/templates/pbs-headless.txt.j2
+++ b/playbooks/roles/cyclecloud_pbs/templates/pbs-headless.txt.j2
@@ -36,8 +36,8 @@ Autoscale = true
         cyclecloud.exports.defaults.samba.enabled = false      
         cshared.server.legacy_links_disabled = true
 
-#        [[[volume boot]]] 
-#        StorageAccountType = StandardSSD_LRS
+        [[[volume boot]]] 
+        StorageAccountType = StandardSSD_LRS
 
 {% for queue in cc_queues %}
     [[nodearray {{ queue.name }}]]


### PR DESCRIPTION
- update the default node configuration to use StandardSSD_LRS for the boot volume
- this will generate a transient error in Cycle when creating the node, which disappear after node bootup
- this will speed up node provisioning time
close #250 