### PR TITLE
fix node renaming issue

### DIFF
--- a/playbooks/roles/cyclecloud_pbs/cluster-init/scripts/0-healthcheck.sh
+++ b/playbooks/roles/cyclecloud_pbs/cluster-init/scripts/0-healthcheck.sh
@@ -10,5 +10,3 @@ systemctl restart healthcheck
 # force run once on startup
 source /opt/cycle/jetpack/system/bin/cyclecloud-env.sh
 healthcheck
-
-

--- a/playbooks/roles/cyclecloud_pbs/cluster-init/scripts/3-joindomain.sh.j2
+++ b/playbooks/roles/cyclecloud_pbs/cluster-init/scripts/3-joindomain.sh.j2
@@ -1,12 +1,14 @@
 #!/bin/bash
+packages="sssd realmd oddjob oddjob-mkhomedir adcli samba-common samba-common-tools krb5-workstation openldap-clients policycoreutils-python"
 
-yum install sssd realmd oddjob oddjob-mkhomedir adcli samba-common samba-common-tools krb5-workstation openldap-clients policycoreutils-python -y
+if ! rpm -q $packages; then
+  yum install -y $packages
+  systemctl restart dbus
+  systemctl restart systemd-logind
+fi
 
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/azure-dns
 echo "RES_OPTIONS=\"timeout:1 attempts:5\"" >> /etc/sysconfig/network 
-
-systemctl restart dbus
-systemctl restart systemd-logind
 
 NAMESERVER={{ ad_dns }}
 
@@ -14,10 +16,9 @@ sed -i "s/nameserver.*/nameserver ${NAMESERVER}\nnameserver 168.63.129.16/g" /et
 
 echo "supersede domain-name-servers ${NAMESERVER};" > /etc/dhcp/dhclient.conf
 echo "append domain-name-servers 168.63.129.16;" >> /etc/dhcp/dhclient.conf
-#systemctl restart NetworkManager
-#sleep 10
+
 sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-#systemctl restart sshd
+
 cat <<EOF >/etc/ssh/ssh_config
 Host *
     StrictHostKeyChecking no
@@ -37,6 +38,10 @@ fi
 
 sed -i 's@use_fully_qualified_names.*@use_fully_qualified_names = False@' /etc/sssd/sssd.conf
 sed -i 's@ldap_id_mapping.*@ldap_id_mapping = False@' /etc/sssd/sssd.conf
+
+# make sure the hostname being renamed has been flushed in file before restarting the NM
+sed -i 's/^DHCP_HOSTNAME$/DHCP_HOSTNAME=$(hostname)/g' /etc/sysconfig/network-scripts/ifcfg-eth0
+hostname > /etc/hostname
 
 systemctl restart NetworkManager
 systemctl restart sssd


### PR DESCRIPTION
- Node renaming was not properly propagated and sometimes was reverting when restarting the NetworkManager. Fix that in the domain join cluster-init script before restarting NM.

- added logs in healthchecks

- do not restart dbus if packages are already installed in the image

close #372 