### PR TITLE
upgrade to pbspro scalelib 2.0.2

### DIFF
--- a/playbooks/roles/pbsserver/files/doqmgr.sh
+++ b/playbooks/roles/pbsserver/files/doqmgr.sh
@@ -8,7 +8,7 @@
 #/opt/pbs/bin/qmgr -c 'set server query_other_jobs = true'
 #/opt/pbs/bin/qmgr -c 'set server scheduler_iteration = 15'
 #/opt/pbs/bin/qmgr -c 'set server flatuid = true'
-/opt/pbs/bin/qmgr -c 'set server job_history_enable=true'
+#/opt/pbs/bin/qmgr -c 'set server job_history_enable=true' # fixed in 2.0.2
 
 function create_resource() {
 	/opt/pbs/bin/qmgr -c "list resource $1" >/dev/null  2>/dev/null   || \

--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -24,8 +24,7 @@
 
 - name: download CycleCloud ScaleLib PBSPro  
   unarchive: 
-    src: "https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.0/cyclecloud-pbspro-pkg-2.0.0.tar.gz"
-#    src: "https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.1/cyclecloud-pbspro-pkg-2.0.1.tar.gz"
+    src: "https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.2/cyclecloud-pbspro-pkg-2.0.2.tar.gz"
     dest: /tmp/
     remote_src: yes
 
@@ -38,20 +37,20 @@
   args:
     chdir: /tmp/cyclecloud-pbspro
 
-- name: Add resources.json
-  copy:
-    src: '{{role_path}}/files/resources.json'
-    dest: /opt/cycle/pbspro/resources.json
+# - name: Add resources.json
+#   copy:
+#     src: '{{role_path}}/files/resources.json'
+#     dest: /opt/cycle/pbspro/resources.json
 
-- name: Add additional resources definition
-  shell: |
-    jq '.default_resources' autoscale.json > default_resources.json
-    jq '. | del(.default_resources) | .default_resources+=$add | .default_resources+=$resources' --argjson add "$(cat resources.json)" autoscale.json --argjson resources "$(cat default_resources.json)" > tmp_autoscale.json || exit 1
-    cp tmp_autoscale.json autoscale.json
-    jq '.' autoscale.json || exit 1
-    rm tmp_autoscale.json
-  args:
-    chdir: /opt/cycle/pbspro
+# - name: Add additional resources definition
+#   shell: |
+#     jq '.default_resources' autoscale.json > default_resources.json
+#     jq '. | del(.default_resources) | .default_resources+=$add | .default_resources+=$resources' --argjson add "$(cat resources.json)" autoscale.json --argjson resources "$(cat default_resources.json)" > tmp_autoscale.json || exit 1
+#     cp tmp_autoscale.json autoscale.json
+#     jq '.' autoscale.json || exit 1
+#     rm tmp_autoscale.json
+#   args:
+#     chdir: /opt/cycle/pbspro
 
 - name: change node timeout to 15mn instead of 5mn
   shell: |


### PR DESCRIPTION
- upgrade pbs scalelib to 2.0.2 https://github.com/Azure/cyclecloud-pbspro/releases/tag/2.0.2
- fix the NDv4 resource issue and add many more missing instance type
- enable job history by default
- do not apply the resources.json as these should be embedded in version 2.0.2

close #385 