### PR TITLE
remove udev rules when building the CentOS 7.9 HPC image

### DIFF
--- a/packer/azhop-centos79-v2-rdma-gpgpu.json
+++ b/packer/azhop-centos79-v2-rdma-gpgpu.json
@@ -30,7 +30,6 @@
             "inline": [
                 "chmod +x /tmp/scripts/*.sh",
                 "/tmp/scripts/linux-setup.sh",
-                "/tmp/scripts/rdma-udev-rules.sh",
                 "/tmp/scripts/pbspro.sh",
                 "/tmp/scripts/telegraf.sh",
                 "/tmp/scripts/lustreclient.sh 2.12.6",


### PR DESCRIPTION
udev rules are already embedded in the marketplace image