### PR TITLE
Allow to deploy in an existing VNET

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,6 @@ if [ $# -eq 0 ]; then
   echo "   "
   echo "  Optional arguments:"
   echo "    -f|-folder <relative path> - relative folder name containing the terraform files, default is ./tf"
-#  echo "    -t|--target <target_resource> - Terraform target resource and dependencies to deploy" 
 
   exit 1
 fi
@@ -30,10 +29,6 @@ while (( "$#" )); do
     ;;
     -f|-folder)
       TF_FOLDER=${THIS_DIR}/${2}
-      shift 2
-    ;;
-    -t|--target)
-      TF_TARGET=${2}
       shift 2
     ;;
     *)
@@ -99,7 +94,6 @@ fi
 azure_user=$(az account show --query user.name -o tsv)
 created_on=$(date -u)
 echo "terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 $PARAMS"
-#  -target=$TF_TARGET \
 
 terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 \
   -var "CreatedBy=$azure_user" \

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set -e
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #TFVARS_FILE=""
 TF_FOLDER=$THIS_DIR/tf
+TF_TARGET=
 if [ $# -eq 0 ]; then
   echo "Usage build.sh "
   echo "  Required arguments:"
@@ -15,6 +16,7 @@ if [ $# -eq 0 ]; then
   echo "   "
   echo "  Optional arguments:"
   echo "    -f|-folder <relative path> - relative folder name containing the terraform files, default is ./tf"
+#  echo "    -t|--target <target_resource> - Terraform target resource and dependencies to deploy" 
 
   exit 1
 fi
@@ -28,6 +30,10 @@ while (( "$#" )); do
     ;;
     -f|-folder)
       TF_FOLDER=${THIS_DIR}/${2}
+      shift 2
+    ;;
+    -t|--target)
+      TF_TARGET=${2}
       shift 2
     ;;
     *)
@@ -93,6 +99,8 @@ fi
 azure_user=$(az account show --query user.name -o tsv)
 created_on=$(date -u)
 echo "terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 $PARAMS"
+#  -target=$TF_TARGET \
+
 terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 \
   -var "CreatedBy=$azure_user" \
   -var "CreatedOn=$created_on" \

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -15,6 +15,26 @@ admin_user: hpcadmin
 key_vault_readers: #<object_id>
 # Network
 network:
+  vnet:
+    name: hpcvnet # Optional - default to hpcvnet
+    id: # If a vnet id is set then no network will be created and the provided vnet will be used
+    address_space: "10.0.0.0/16" # Optional - default to "10.0.0.0/16"
+    # When using an existing VNET, only the subnet names will be used and not the adress_prefixes
+    subnets: # all subnets are optionals
+    # name values can be used to rename the default to specific names, address_prefixes to change the IP ranges to be used
+    # All values below are the default values
+      frontend: 
+        name: frontend
+        address_prefixes: "10.0.0.0/24"
+      admin:
+        name: admin
+        address_prefixes: "10.0.1.0/24"
+      netapp:
+        name: netapp
+        address_prefixes: "10.0.2.0/24"
+      compute:
+        name: compute
+        address_prefixes: "10.0.16.0/20"
   peering: # This is optional, and can be used to create a VNet Peering in the same subscription.
     vnet_name: #"VNET Name to Peer to"
     vnet_resource_group: #"Resource Group of the VNET to peer to"

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -79,8 +79,8 @@ lustre:
   hsm:
     # optional to use existing storage for the archive
     # if not included it will use the azhop storage account that is created
-    storage_account: "existing_storage_account_name"
-    storage_container: "only_used_with_existing_storage_account"
+    storage_account: #existing_storage_account_name
+    storage_container: #only_used_with_existing_storage_account
 # List of users to be created on this environment
 users:
   - name: user1

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -20,6 +20,26 @@ admin_user: hpcadmin
 key_vault_readers: #<object_id>
 # Network
 network:
+  vnet:
+    name: hpcvnet # Optional - default to hpcvnet
+    id: # If a vnet id is set then no network will be created and the provided vnet will be used
+    address_space: "10.0.0.0/16" # Optional - default to "10.0.0.0/16"
+    # When using an existing VNET, only the subnet names will be used and not the adress_prefixes
+    subnets: # all subnets are optionals
+    # name values can be used to rename the default to specific names, address_prefixes to change the IP ranges to be used
+    # All values below are the default values
+      frontend: 
+        name: frontend
+        address_prefixes: "10.0.0.0/24"
+      admin:
+        name: admin
+        address_prefixes: "10.0.1.0/24"
+      netapp:
+        name: netapp
+        address_prefixes: "10.0.2.0/24"
+      compute:
+        name: compute
+        address_prefixes: "10.0.16.0/20"
   peering: # This is optional, and can be used to create a VNet Peering in the same subscription.
     vnet_name: #"VNET Name to Peer to"
     vnet_resource_group: #"Resource Group of the VNET to peer to"
@@ -64,8 +84,8 @@ lustre:
   hsm:
     # optional to use existing storage for the archive
     # if not included it will use the azhop storage account that is created
-    storage_account: "existing_storage_account_name"
-    storage_container: "only_used_with_existing_storage_account"
+    storage_account: # existing_storage_account_name
+    storage_container: #only_used_with_existing_storage_account
 # List of users to be created on this environment
 users:
   - name: user1

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -1,0 +1,40 @@
+# How To
+
+- [How to use an existing VNET ?](#how-to-use-an-existing-vnet)
+  - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
+
+## How to use an existing VNET ?
+Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.
+
+```yml
+network:
+  vnet:
+    id: /subscriptions/<subscription id>/resourceGroups/<vnet resource group>/providers/Microsoft.Network/virtualNetworks/<vnet name>
+```
+
+**azhop** subnet names can be mapped to existing subnets names in the provided vnet by specifying then as below. 
+> Note : The same subnet name can be used multiple times if needed.
+
+```yml
+network:
+  vnet:
+    id: /subscriptions/<subscription id>/resourceGroups/<vnet resource group>/providers/Microsoft.Network/virtualNetworks/<vnet name>
+    subnets:
+      frontend: 
+        name: ondemand
+      admin:
+        name: itonly
+      netapp:
+        name: storage
+      compute:
+        name: dynamic
+```
+
+### Pre-requisities for using an existing VNET
+- There is a need of a minimum of 5 IP addresses for the infrastructure VMs
+- Allow enough IP addresses for the Lustre cluster, default being 4 : Robinhood + Lustre + 2*OSS
+- Delegate a subnet to Azure NetApp Files like documented [here](https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-delegate-subnet)
+- The *frontend* subnet needs to allow this traffic :
+  - HTTPS/443 In => this is used by the OnDemand web portal and all end users
+  - SSH/22 In => This is used when doing the deployment and by admins only
+

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -2,6 +2,7 @@
 
 - [How to use an existing VNET ?](#how-to-use-an-existing-vnet)
   - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
+  - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
 
 ## How to use an existing VNET ?
 Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.
@@ -38,3 +39,9 @@ network:
   - HTTPS/443 In => this is used by the OnDemand web portal and all end users
   - SSH/22 In => This is used when doing the deployment and by admins only
 
+### Creating a standalone VNET for AZ-HOP
+There is a way to easily create a standalone VNET for **azhop** without doing a full deployment by following these steps :
+- Create a configuration file with all the required values for creating a VNET
+- run the build command specify the *tf/network* subdirectory `./build -a [plan, apply, destroy] -tf ./tf/network`
+- Save your config file and create a new one in which you now specify the VNET ID created above
+- Build your **azhop** environment

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -7,3 +7,4 @@
  - [Add Users](add_users.md)
  - [Admin Access](admin_access.md)
  - [Helper Scripts](helper_scripts)
+ - [How to](how_to.md)

--- a/playbooks/ccpbs.yml
+++ b/playbooks/ccpbs.yml
@@ -62,7 +62,7 @@
         become: true
     vars:
       cc_region: '{{location}}'
-      cc_subnetid: '{{ resource_group }}/hpcvnet/compute'
+      cc_subnetid: '{{cc_subnetid}}'
       cc_admin_user: '{{admin_user}}'
       cc_password: '{{password.stdout}}'
       cc_queues: '{{queues}}'

--- a/playbooks/ccpbs.yml
+++ b/playbooks/ccpbs.yml
@@ -62,7 +62,7 @@
         become: true
     vars:
       cc_region: '{{location}}'
-      cc_subnetid: '{{cc_subnetid}}'
+      cc_subnetid: '{{compute_subnetid}}'
       cc_admin_user: '{{admin_user}}'
       cc_password: '{{password.stdout}}'
       cc_queues: '{{queues}}'

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -28,8 +28,8 @@
       apply: 
         become: true
     vars:
-      cc_region: '{{location}}'
-      cc_subnetid: '{{cc_subnetid}}'
+      # cc_region: '{{location}}'
+      # cc_subnetid: '{{compute_subnetid}}'
       cc_admin_user: '{{admin_user}}'
       cc_public_key: '{{global_ssh_public_key}}'
       cc_password: '{{password.stdout}}'

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -29,7 +29,7 @@
         become: true
     vars:
       cc_region: '{{location}}'
-      cc_subnetid: '{{ resource_group }}/hpcvnet/compute'
+      cc_subnetid: '{{cc_subnetid}}'
       cc_admin_user: '{{admin_user}}'
       cc_public_key: '{{global_ssh_public_key}}'
       cc_password: '{{password.stdout}}'

--- a/tf/ad.tf
+++ b/tf/ad.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_interface" "ad-nic" {
   name                = "ad-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
 
   ip_configuration {
     name                          = "internal"
@@ -12,8 +12,8 @@ resource "azurerm_network_interface" "ad-nic" {
 
 resource "azurerm_windows_virtual_machine" "ad" {
   name                = "ad"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   size                = try(local.configuration_yml["ad"].vm_size, "Standard_D2s_v3")
   admin_username      = local.admin_username
   admin_password      = random_password.password.result 

--- a/tf/ad.tf
+++ b/tf/ad.tf
@@ -5,7 +5,7 @@ resource "azurerm_network_interface" "ad-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/tf/anf.tf
+++ b/tf/anf.tf
@@ -1,13 +1,14 @@
 resource "azurerm_netapp_account" "azhop" {
   name                = "hpcanf-${random_string.resource_postfix.result}"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 }
+
 resource "azurerm_netapp_pool" "anfpool" {
   name                = "anfpool-${random_string.resource_postfix.result}"
   account_name        = azurerm_netapp_account.azhop.name
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_netapp_account.azhop.location
+  resource_group_name = azurerm_netapp_account.azhop.resource_group_name
   service_level       = local.homefs_service_level
   size_in_tb          = local.homefs_size_tb
 }
@@ -17,8 +18,8 @@ resource "azurerm_netapp_volume" "home" {
 #  }
 
   name                = "anfhome"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_netapp_account.azhop.location
+  resource_group_name = azurerm_netapp_account.azhop.resource_group_name
   account_name        = azurerm_netapp_account.azhop.name
   pool_name           = azurerm_netapp_pool.anfpool.name
   volume_path         = "home-${random_string.resource_postfix.result}"

--- a/tf/anf.tf
+++ b/tf/anf.tf
@@ -23,7 +23,7 @@ resource "azurerm_netapp_volume" "home" {
   pool_name           = azurerm_netapp_pool.anfpool.name
   volume_path         = "home-${random_string.resource_postfix.result}"
   service_level       = local.homefs_service_level
-  subnet_id           = azurerm_subnet.netapp.id
+  subnet_id           = local.create_vnet ? azurerm_subnet.netapp[0].id : data.azurerm_subnet.netapp[0].id
   protocols           = ["NFSv3"]
   storage_quota_in_gb = local.homefs_size_tb * 1024
 

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -7,7 +7,7 @@ resource "azurerm_network_interface" "ccportal-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -2,8 +2,8 @@ data "azurerm_subscription" "primary" {}
 
 resource "azurerm_network_interface" "ccportal-nic" {
   name                = "ccportal-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -14,8 +14,8 @@ resource "azurerm_network_interface" "ccportal-nic" {
 
 resource "azurerm_virtual_machine" "ccportal" {
   name                  = "ccportal"
-  resource_group_name   = azurerm_resource_group.rg.name
-  location              = azurerm_resource_group.rg.location
+  location              = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name   = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   vm_size               = try(local.configuration_yml["cyclecloud"].vm_size, "Standard_D2s_v3")
   network_interface_ids = [
     azurerm_network_interface.ccportal-nic.id,

--- a/tf/jumpbox.tf
+++ b/tf/jumpbox.tf
@@ -12,7 +12,7 @@ resource "azurerm_network_interface" "jumpbox-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.frontend.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = azurerm_public_ip.jumpbox-pip.id
   }

--- a/tf/jumpbox.tf
+++ b/tf/jumpbox.tf
@@ -1,14 +1,14 @@
 resource "azurerm_public_ip" "jumpbox-pip" {
   name                = "jumpbox-pip"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "jumpbox-nic" {
   name                = "jumpbox-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -20,8 +20,8 @@ resource "azurerm_network_interface" "jumpbox-nic" {
 
 resource "azurerm_linux_virtual_machine" "jumpbox" {
   name                = "jumpbox"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                = "Standard_D2s_v3"
   admin_username      = local.admin_username
   network_interface_ids = [

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -10,8 +10,8 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "azhop" {
   name                        = format("%s%s", "kv", random_string.resource_postfix.result)
-  location                    = azurerm_resource_group.rg.location
-  resource_group_name         = azurerm_resource_group.rg.name
+  location                    = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name         = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   soft_delete_enabled         = true

--- a/tf/lustre.tf
+++ b/tf/lustre.tf
@@ -13,8 +13,8 @@ locals {
 
 resource "azurerm_network_interface" "lustre-nic" {
   name                = "lustre-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -25,8 +25,8 @@ resource "azurerm_network_interface" "lustre-nic" {
 
 resource "azurerm_linux_virtual_machine" "lustre" {
   name                  = "lustre"
-  resource_group_name   = azurerm_resource_group.rg.name
-  location              = azurerm_resource_group.rg.location
+  location              = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name   = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                  = local.lustre_mds_sku
   network_interface_ids = [
     azurerm_network_interface.lustre-nic.id,
@@ -57,8 +57,8 @@ resource "azurerm_linux_virtual_machine" "lustre" {
 #
 
 resource "azurerm_user_assigned_identity" "lustre-oss" {
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   name = "lustre-oss"
 }
@@ -66,8 +66,8 @@ resource "azurerm_user_assigned_identity" "lustre-oss" {
 resource "azurerm_network_interface" "lustre-oss-nic" {
   count               = local.lustre_oss_count
   name                = "lustre-oss-nic-${count.index}"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -79,8 +79,8 @@ resource "azurerm_network_interface" "lustre-oss-nic" {
 resource "azurerm_linux_virtual_machine" "lustre-oss" {
   count                 = local.lustre_oss_count
   name                  = "lustre-oss-${count.index}"
-  resource_group_name   = azurerm_resource_group.rg.name
-  location              = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                  = local.lustre_oss_sku
   network_interface_ids = [
     element(azurerm_network_interface.lustre-oss-nic.*.id, count.index)
@@ -140,8 +140,8 @@ resource "azurerm_key_vault_access_policy" "lustre-oss" {
 
 resource "azurerm_network_interface" "robinhood-nic" {
   name                = "robinhood-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -152,8 +152,8 @@ resource "azurerm_network_interface" "robinhood-nic" {
 
 resource "azurerm_linux_virtual_machine" "robinhood" {
   name                  = "robinhood"
-  resource_group_name   = azurerm_resource_group.rg.name
-  location              = azurerm_resource_group.rg.location
+  location              = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name   = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                  = local.lustre_mds_sku
   network_interface_ids = [
     azurerm_network_interface.robinhood-nic.id,

--- a/tf/lustre.tf
+++ b/tf/lustre.tf
@@ -18,7 +18,7 @@ resource "azurerm_network_interface" "lustre-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }
@@ -71,7 +71,7 @@ resource "azurerm_network_interface" "lustre-oss-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }
@@ -145,7 +145,7 @@ resource "azurerm_network_interface" "robinhood-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -34,7 +34,14 @@ resource "random_password" "password" {
   override_special  = "_%@"
 }
 
+data "azurerm_resource_group" "rg" {
+  count    = local.create_rg ? 0 : 1
+  name     = local.resource_group
+}
+
+
 resource "azurerm_resource_group" "rg" {
+  count    = local.create_rg ? 1 : 0
   name     = local.resource_group
   location = local.location
   tags = {
@@ -65,8 +72,8 @@ resource "local_file" "public_key" {
 #   - Terraform states
 resource "azurerm_storage_account" "azhop" {
   name                     = "azhop${random_string.resource_postfix.result}"
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  location                 = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -1,26 +1,64 @@
+# Main VNET
+data "azurerm_virtual_network" "azhop" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(split("/", local.vnet_id)[8], "foo")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+}
+
 resource "azurerm_virtual_network" "azhop" {
-  name                = "hpcvnet"
+  count               = local.create_vnet ? 1 : 0
+  name                = try(local.configuration_yml["network"]["vnet"]["name"], "hpcvnet")
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
-  address_space       = ["10.0.0.0/16"]
+  address_space       = [try(local.configuration_yml["network"]["vnet"]["address_space"], "10.0.0.0/16")]
 }
+
+# Frontend Subnet
+data "azurerm_subnet" "frontend" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["frontend"]["name"], "frontend")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+  virtual_network_name = try(split("/", local.vnet_id)[8], "foo")
+}
+
 resource "azurerm_subnet" "frontend" {
-  name                 = "frontend"
-  virtual_network_name = azurerm_virtual_network.azhop.name
-  resource_group_name  = azurerm_resource_group.rg.name
-  address_prefixes     = ["10.0.0.0/24"]
+  count                = local.create_vnet ? 1 : 0
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["frontend"]["name"], "frontend")
+  virtual_network_name = azurerm_virtual_network.azhop[count.index].name
+  resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
+  address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["frontend"]["address_prefixes"], "10.0.0.0/24")]
 }
+
+# admin subnet
+data "azurerm_subnet" "admin" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["admin"]["name"], "admin")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+  virtual_network_name = try(split("/", local.vnet_id)[8], "foo")
+}
+
 resource "azurerm_subnet" "admin" {
+  count                = local.create_vnet ? 1 : 0
   name                 = "admin"
-  virtual_network_name = azurerm_virtual_network.azhop.name
-  resource_group_name  = azurerm_resource_group.rg.name
-  address_prefixes     = ["10.0.1.0/24"]
+  virtual_network_name = azurerm_virtual_network.azhop[count.index].name
+  resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
+  address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["admin"]["address_prefixes"], "10.0.1.0/24")]
 }
+
+# netapp subnet
+data "azurerm_subnet" "netapp" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["netapp"]["name"], "netapp")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+  virtual_network_name = try(split("/", local.vnet_id)[8], "foo")
+}
+
 resource "azurerm_subnet" "netapp" {
+  count                = local.create_vnet ? 1 : 0
   name                 = "netapp"
-  virtual_network_name = azurerm_virtual_network.azhop.name
-  resource_group_name  = azurerm_resource_group.rg.name
-  address_prefixes     = ["10.0.2.0/24"]
+  virtual_network_name = azurerm_virtual_network.azhop[count.index].name
+  resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
+  address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["netapp"]["address_prefixes"], "10.0.2.0/24")]
   delegation {
     name = "netapp"
 
@@ -36,15 +74,26 @@ resource "azurerm_subnet" "netapp" {
 #  resource_group_name  = azurerm_resource_group.rg.name
 #  address_prefixes     = ["10.0.3.0/24"]
 #}
+
+# compute subnet
+data "azurerm_subnet" "compute" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["compute"]["name"], "compute")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+  virtual_network_name = try(split("/", local.vnet_id)[8], "foo")
+}
+
 resource "azurerm_subnet" "compute" {
+  count                = local.create_vnet ? 1 : 0
   name                 = "compute"
-  virtual_network_name = azurerm_virtual_network.azhop.name
-  resource_group_name  = azurerm_resource_group.rg.name
-  address_prefixes     = ["10.0.16.0/20"]
+  virtual_network_name = azurerm_virtual_network.azhop[count.index].name
+  resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
+  address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["compute"]["address_prefixes"], "10.0.16.0/20")]
 }
 
 # Network security group for the FrontEnd subnet
 resource "azurerm_network_security_group" "frontend" {
+  count                = local.create_vnet ? 1 : 0
   name                = "frontendnsg"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
@@ -87,6 +136,7 @@ resource "azurerm_network_security_group" "frontend" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "frontend" {
-  subnet_id                 = azurerm_subnet.frontend.id
-  network_security_group_id = azurerm_network_security_group.frontend.id
+  count                     = local.create_vnet ? 1 : 0
+  subnet_id                 = azurerm_subnet.frontend[count.index].id
+  network_security_group_id = azurerm_network_security_group.frontend[count.index].id
 }

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -8,8 +8,8 @@ data "azurerm_virtual_network" "azhop" {
 resource "azurerm_virtual_network" "azhop" {
   count               = local.create_vnet ? 1 : 0
   name                = try(local.configuration_yml["network"]["vnet"]["name"], "hpcvnet")
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg[0].name
+  location            = azurerm_resource_group.rg[0].location
   address_space       = [try(local.configuration_yml["network"]["vnet"]["address_space"], "10.0.0.0/16")]
 }
 
@@ -95,8 +95,8 @@ resource "azurerm_subnet" "compute" {
 resource "azurerm_network_security_group" "frontend" {
   count                = local.create_vnet ? 1 : 0
   name                = "frontendnsg"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg[0].location
+  resource_group_name = azurerm_resource_group.rg[0].name
 
   security_rule {
         name                       = "ssh-in-allow-22"

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -39,7 +39,7 @@ data "azurerm_subnet" "admin" {
 
 resource "azurerm_subnet" "admin" {
   count                = local.create_vnet ? 1 : 0
-  name                 = "admin"
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["admin"]["name"], "admin")
   virtual_network_name = azurerm_virtual_network.azhop[count.index].name
   resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
   address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["admin"]["address_prefixes"], "10.0.1.0/24")]
@@ -55,7 +55,7 @@ data "azurerm_subnet" "netapp" {
 
 resource "azurerm_subnet" "netapp" {
   count                = local.create_vnet ? 1 : 0
-  name                 = "netapp"
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["netapp"]["name"], "netapp")
   virtual_network_name = azurerm_virtual_network.azhop[count.index].name
   resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
   address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["netapp"]["address_prefixes"], "10.0.2.0/24")]
@@ -85,7 +85,7 @@ data "azurerm_subnet" "compute" {
 
 resource "azurerm_subnet" "compute" {
   count                = local.create_vnet ? 1 : 0
-  name                 = "compute"
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["compute"]["name"], "compute")
   virtual_network_name = azurerm_virtual_network.azhop[count.index].name
   resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
   address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["compute"]["address_prefixes"], "10.0.16.0/20")]

--- a/tf/network/main.tf
+++ b/tf/network/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.41.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_resource_group" "rg" {
+  count    = local.create_rg ? 0 : 1
+  name     = local.resource_group
+}
+
+
+resource "azurerm_resource_group" "rg" {
+  count    = local.create_rg ? 1 : 0
+  name     = local.resource_group
+  location = local.location
+  tags = {
+    CreatedBy = var.CreatedBy
+    CreatedOn = var.CreatedOn
+  }
+}
+

--- a/tf/network/network.tf
+++ b/tf/network/network.tf
@@ -1,0 +1,1 @@
+../network.tf

--- a/tf/network/variables.tf
+++ b/tf/network/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/tf/network/variables_local.tf
+++ b/tf/network/variables_local.tf
@@ -1,0 +1,1 @@
+../variables_local.tf

--- a/tf/network_peering.tf
+++ b/tf/network_peering.tf
@@ -9,7 +9,7 @@ data "azurerm_virtual_network" "peernetwork" {
 resource "azurerm_virtual_network_peering" "azhop-to-peer" {
   count                         = local.create_peering
   name                          = "azhop-to-peer"
-  resource_group_name           = azurerm_resource_group.rg.name
+  resource_group_name           = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   virtual_network_name          = azurerm_virtual_network.azhop[0].name
   remote_virtual_network_id     = data.azurerm_virtual_network.peernetwork[count.index].id
   allow_virtual_network_access  = true

--- a/tf/network_peering.tf
+++ b/tf/network_peering.tf
@@ -10,7 +10,7 @@ resource "azurerm_virtual_network_peering" "azhop-to-peer" {
   count                         = local.create_peering
   name                          = "azhop-to-peer"
   resource_group_name           = azurerm_resource_group.rg.name
-  virtual_network_name          = azurerm_virtual_network.azhop.name
+  virtual_network_name          = azurerm_virtual_network.azhop[0].name
   remote_virtual_network_id     = data.azurerm_virtual_network.peernetwork[count.index].id
   allow_virtual_network_access  = true
   allow_forwarded_traffic       = true
@@ -21,7 +21,7 @@ resource "azurerm_virtual_network_peering" "peer-to-azhop" {
   name                          = "peer-to-azhop"
   resource_group_name           = data.azurerm_virtual_network.peernetwork[count.index].resource_group_name
   virtual_network_name          = data.azurerm_virtual_network.peernetwork[count.index].name
-  remote_virtual_network_id     = azurerm_virtual_network.azhop.id
+  remote_virtual_network_id     = azurerm_virtual_network.azhop[0].id
   allow_virtual_network_access  = true
   allow_forwarded_traffic       = true
 }

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -1,15 +1,15 @@
 resource "azurerm_public_ip" "ondemand-pip" {
   name                = "ondemand-pip"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   allocation_method   = "Static"
   domain_name_label   = "ondemand${random_string.resource_postfix.result}"
 }
 
 resource "azurerm_network_interface" "ondemand-nic" {
   name                = "ondemand-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -21,8 +21,8 @@ resource "azurerm_network_interface" "ondemand-nic" {
 
 resource "azurerm_linux_virtual_machine" "ondemand" {
   name                = "ondemand"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                = try(local.configuration_yml["ondemand"].vm_size, "Standard_D2s_v3")
   admin_username      = local.admin_username
   network_interface_ids = [

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -13,7 +13,7 @@ resource "azurerm_network_interface" "ondemand-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.frontend.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = azurerm_public_ip.ondemand-pip.id
   }

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -23,7 +23,7 @@ resource "local_file" "global_variables" {
       admin_username      = local.admin_username
       ssh_public_key      = tls_private_key.internal.public_key_openssh
       cc_storage          = azurerm_storage_account.azhop.name
-      cc_subnetid         = local.create_vnet ? "${azurerm_subnet.compute[0].resource_group_name}/${azurerm_subnet.compute[0].virtual_network_name}/${azurerm_subnet.compute[0].name}" : "${data.azurerm_subnet.compute[0].resource_group_name}/${data.azurerm_subnet.compute[0].virtual_network_name}/${data.azurerm_subnet.compute[0].name}"
+      compute_subnetid    = local.create_vnet ? "${azurerm_subnet.compute[0].resource_group_name}/${azurerm_subnet.compute[0].virtual_network_name}/${azurerm_subnet.compute[0].name}" : "${data.azurerm_subnet.compute[0].resource_group_name}/${data.azurerm_subnet.compute[0].virtual_network_name}/${data.azurerm_subnet.compute[0].name}"
       region              = local.location
       resource_group      = local.resource_group
       config_file         = local.configuration_file

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -23,6 +23,7 @@ resource "local_file" "global_variables" {
       admin_username      = local.admin_username
       ssh_public_key      = tls_private_key.internal.public_key_openssh
       cc_storage          = azurerm_storage_account.azhop.name
+      cc_subnetid         = local.create_vnet ? "${azurerm_subnet.compute[0].resource_group_name}/${azurerm_subnet.compute[0].virtual_network_name}/${azurerm_subnet.compute[0].name}" : "${data.azurerm_subnet.compute[0].resource_group_name}/${data.azurerm_subnet.compute[0].virtual_network_name}/${data.azurerm_subnet.compute[0].name}"
       region              = local.location
       resource_group      = local.resource_group
       config_file         = local.configuration_file

--- a/tf/scheduler.tf
+++ b/tf/scheduler.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_interface" "scheduler-nic" {
   name                = "scheduler-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
   ip_configuration {
     name                          = "internal"
@@ -12,8 +12,8 @@ resource "azurerm_network_interface" "scheduler-nic" {
 
 resource "azurerm_linux_virtual_machine" "scheduler" {
   name                = "scheduler"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                = try(local.configuration_yml["scheduler"].vm_size, "Standard_D2s_v3")
   admin_username      = local.admin_username
   network_interface_ids = [

--- a/tf/scheduler.tf
+++ b/tf/scheduler.tf
@@ -5,7 +5,7 @@ resource "azurerm_network_interface" "scheduler-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.admin.id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/tf/sig.tf
+++ b/tf/sig.tf
@@ -1,7 +1,7 @@
 resource "azurerm_shared_image_gallery" "sig" {
   name                = "azhop_${random_string.resource_postfix.result}"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   description         = "Shared images for AZHOP"
 }
 

--- a/tf/templates/global_variables.tmpl
+++ b/tf/templates/global_variables.tmpl
@@ -1,6 +1,6 @@
 global_ssh_public_key         : '${ssh_public_key}'
 global_cc_storage             : ${cc_storage}
-cc_subnetid                   : ${cc_subnetid}
+compute_subnetid              : ${compute_subnetid}
 global_config_file            : ${config_file}
 ad_dns                        : ${ad-ip}
 ad_join_user                  : ${admin_username}

--- a/tf/templates/global_variables.tmpl
+++ b/tf/templates/global_variables.tmpl
@@ -1,5 +1,6 @@
 global_ssh_public_key         : '${ssh_public_key}'
 global_cc_storage             : ${cc_storage}
+cc_subnetid                   : ${cc_subnetid}
 global_config_file            : ${config_file}
 ad_dns                        : ${ad-ip}
 ad_join_user                  : ${admin_username}

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -3,7 +3,7 @@ locals {
     packer_root_dir = "${path.root}/../packer"
     playbook_root_dir = "${path.root}/../playbooks"
     playbooks_template_dir = "${path.root}/templates"
-    configuration_file="${path.root}/../config.yml"
+    configuration_file="${path.cwd}/config.yml"
     configuration_yml=yamldecode(file(local.configuration_file))
     
     # Load pamareters from the configuration file

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -20,6 +20,11 @@ locals {
     lustre_oss_sku = try(local.configuration_yml["lustre"]["oss_sku"], "Standard_D32d_v4")
     lustre_oss_count = try(local.configuration_yml["lustre"]["oss_count"], 2)
 
+    # VNET
+    create_vnet = try(length(local.vnet_id) > 0 ? false : true, true)
+    vnet_id = try(local.configuration_yml["network"]["vnet"]["id"], null)
+
+    # VNET Peering
     create_peering = try(length(local.peering_vnet_name) > 0 ? 1 : 0, 0)
     peering_vnet_name = try(local.configuration_yml["network"]["peering"]["vnet_name"], null)
     peering_vnet_resource_group = try(local.configuration_yml["network"]["peering"]["vnet_resource_group"], null)

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -1,20 +1,25 @@
 locals {
+    # config files and directories
     packer_root_dir = "${path.root}/../packer"
     playbook_root_dir = "${path.root}/../playbooks"
     playbooks_template_dir = "${path.root}/templates"
     configuration_file="${path.root}/../config.yml"
     configuration_yml=yamldecode(file(local.configuration_file))
     
+    # Load pamareters from the configuration file
     location = local.configuration_yml["location"]
     resource_group = local.configuration_yml["resource_group"]
+    # Create the RG if creating a VNET or when reusing a VNET in another resource group
+    create_rg = local.create_vnet || try(split("/", local.vnet_id)[4], local.resource_group) != local.resource_group
+
     homefs_size_tb = try(local.configuration_yml["homefs_size_tb"], 4)
     homefs_service_level = try(local.configuration_yml["homefs_service_level"], "Standard")
     admin_username = local.configuration_yml["admin_user"]
     homedir_mountpoint = local.configuration_yml["homedir_mountpoint"]
     key_vault_readers = try(local.configuration_yml["key_vault_readers"], null)
 
+    # Lustre
     lustre_archive_account = try(local.configuration_yml["lustre"]["hsm"]["storage_account"], null)
-
     lustre_rbh_sku = try(local.configuration_yml["lustre"]["rhb_sku"], "Standard_D8d_v4")
     lustre_mds_sku = try(local.configuration_yml["lustre"]["mds_sku"], "Standard_D8d_v4")
     lustre_oss_sku = try(local.configuration_yml["lustre"]["oss_sku"], "Standard_D32d_v4")


### PR DESCRIPTION
- added VNET and Subnet sections in the configuration file
- if a VNET ID is specified used it and don't create a VNET
- AZ HOP can be deployed in the same RG than the specified VNET
- added params for subnet names and IP ranges
- VNET IP Range can be specified
- documented default values in the config template and documentation


close #171 