### PR TITLE
Allow deploying with an SPN account

### DIFF
--- a/docs/deploy/azure_prereqs.md
+++ b/docs/deploy/azure_prereqs.md
@@ -1,6 +1,7 @@
 # Azure Pre-requisites
 
-- You need to be owner of your subscription
+- When using a user account you need to be **Owner** of the subscription
+- When using a Service Principal Name, it need to be **Contributor** and **User Access Administrator** on the subscription
 - Your subscription need to be registered for NetApp resource provider as explained [here](https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-register#waitlist)
 - The CycleCloud marketplace image need to be allowed, this is the default unless your subscription have a policy blocking it. The EULA terms need to be accepted, this is done in the build script, but if you are not granted to do so, ask your adimnistrator to run this command :
 ```bash

--- a/docs/deploy/deploy.md
+++ b/docs/deploy/deploy.md
@@ -29,7 +29,7 @@ az account set -s <subid>
 ### Deploy with a Service Principal Name 
 When using a Service Principal Name (SPN), you have to login to Azure with this SPN but also set the environment variables used by Terraform to build resources as explained [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret).
 
-> Note : The SPN need to have contributor access on the subscription
+> Note : The SPN need to have **contributor** and **User Access Administrator** roles on the subscription
 
 ```bash
 # Login to Azure 

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -61,9 +61,6 @@ resource "azurerm_virtual_machine" "ccportal" {
     disk_size_gb      = 128
   }
 
-  # identity {
-  #   type = "SystemAssigned"
-  # }
   identity {
     type         = "UserAssigned"
     identity_ids = [ azurerm_user_assigned_identity.ccportal.id ]
@@ -140,27 +137,6 @@ resource "azurerm_role_assignment" "ccportal_rg" {
   name               = azurerm_user_assigned_identity.ccportal.principal_id
   scope              = azurerm_resource_group.rg[0].id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
-  #role_definition_id = azurerm_role_definition.cyclecloud.role_definition_resource_id
   principal_id       = azurerm_user_assigned_identity.ccportal.principal_id
 }
-
-# Grant Contributor access to Cycle in the resource group of the existing VNET
-resource "random_uuid" "ccportal_existing_vnet_rg" {}
-
-resource "azurerm_role_assignment" "ccportal_existing_vnet_rg" {
-  count              = local.create_vnet ? 0 : 1
-  name               = random_uuid.ccportal_existing_vnet_rg.result
-  scope              = data.azurerm_resource_group.rg_vnet[0].id
-  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
-  principal_id       = azurerm_user_assigned_identity.ccportal.principal_id
-}
-
-# Original role assignment when doing SystemAssignment and Contributor role
-
-# resource "azurerm_role_assignment" "ccportal" {
-#   name               = lookup(azurerm_virtual_machine.ccportal.identity[0], "principal_id")
-#   scope              = data.azurerm_subscription.primary.id
-#   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
-#   principal_id       = lookup(azurerm_virtual_machine.ccportal.identity[0], "principal_id")
-# }
 

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -85,6 +85,7 @@ resource "azurerm_user_assigned_identity" "ccportal" {
 # resource "random_uuid" "role" {
 # }
 
+
 # resource "azurerm_role_definition" "cyclecloud" {
 #   role_definition_id = random_uuid.role.result
 #   name               = "CycleCloud-${random_string.resource_postfix.result}"
@@ -138,7 +139,7 @@ resource "azurerm_user_assigned_identity" "ccportal" {
 
 resource "azurerm_role_assignment" "ccportal" {
   name               = azurerm_user_assigned_identity.ccportal.principal_id
-  scope              = azurerm_resource_group.rg.id #data.azurerm_subscription.primary.id
+  scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
   #role_definition_id = azurerm_role_definition.cyclecloud.role_definition_resource_id
   principal_id       = azurerm_user_assigned_identity.ccportal.principal_id

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -1,5 +1,3 @@
-data "azurerm_subscription" "primary" {}
-
 resource "azurerm_network_interface" "ccportal-nic" {
   name                = "ccportal-nic"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -4,9 +4,6 @@ resource "time_sleep" "delay_create" {
 }
 
 data "azurerm_client_config" "current" {}
-# data "azurerm_role_definition" "owner" {
-#   name = "Owner"
-# }
 
 resource "azurerm_key_vault" "azhop" {
   name                        = format("%s%s", "kv", random_string.resource_postfix.result)
@@ -41,24 +38,6 @@ resource "azurerm_key_vault_access_policy" "admin" {
       "restore"
     ]
 }
-
-# Access Policy can only be granted on Principals and not Roles
-# resource "azurerm_key_vault_access_policy" "owner" {
-
-#   key_vault_id = azurerm_key_vault.azhop.id
-#   tenant_id    = data.azurerm_client_config.current.tenant_id
-#   object_id    = regex("[0-9a-f-]{36}.?", data.azurerm_role_definition.owner.id)
-
-#   secret_permissions = [
-#       "get",
-#       "set",
-#       "list",
-#       "delete",
-#       "purge",
-#       "recover",
-#       "restore"
-#     ]
-# }
 
 # Only create the reader access policy when the key_vault_reader is set
 resource "azurerm_key_vault_access_policy" "reader" {

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -3,8 +3,6 @@ resource "time_sleep" "delay_create" {
   create_duration = "20s"
 }
 
-data "azurerm_client_config" "current" {}
-
 resource "azurerm_key_vault" "azhop" {
   name                        = format("%s%s", "kv", random_string.resource_postfix.result)
   location                    = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -60,8 +60,9 @@ resource "azurerm_key_vault_access_policy" "admin" {
 #     ]
 # }
 
+# Only create the reader access policy when the key_vault_reader is set
 resource "azurerm_key_vault_access_policy" "reader" {
-
+  count = local.key_vault_readers != null ? 1 : 0
   key_vault_id = azurerm_key_vault.azhop.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = local.key_vault_readers != null ? local.key_vault_readers : data.azurerm_client_config.current.object_id

--- a/tf/lustre.tf
+++ b/tf/lustre.tf
@@ -81,8 +81,8 @@ resource "azurerm_network_interface" "lustre-oss-nic" {
 resource "azurerm_linux_virtual_machine" "lustre-oss" {
   count                 = local.lustre_oss_count
   name                  = "lustre-oss-${count.index}"
-  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
-  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  location              = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name   = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   size                  = local.lustre_oss_sku
   network_interface_ids = [
     element(azurerm_network_interface.lustre-oss-nic.*.id, count.index)
@@ -113,20 +113,7 @@ resource "azurerm_linux_virtual_machine" "lustre-oss" {
   }
 }
 
-# add contributor to the subscription
-# (using the data below from the ccportal.tf)
-#data "azurerm_subscription" "primary" {}
-#data "azurerm_role_definition" "contributor" {
-#  name = "Contributor"
-#}
-# resource "azurerm_role_assignment" "lustre-oss" {
-#   name               = azurerm_user_assigned_identity.lustre-oss.principal_id
-#   scope              = data.azurerm_subscription.primary.id
-#   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
-#   principal_id       = azurerm_user_assigned_identity.lustre-oss.principal_id
-# }
-# (using this from keyvault.tf)
-#data "azurerm_client_config" "current" {}
+# Grant read access to the Keyvault for the lustre-oss identity
 resource "azurerm_key_vault_access_policy" "lustre-oss" {
   key_vault_id = azurerm_key_vault.azhop.id
   tenant_id    = data.azurerm_client_config.current.tenant_id

--- a/tf/lustre.tf
+++ b/tf/lustre.tf
@@ -117,12 +117,12 @@ resource "azurerm_linux_virtual_machine" "lustre-oss" {
 #data "azurerm_role_definition" "contributor" {
 #  name = "Contributor"
 #}
-resource "azurerm_role_assignment" "lustre-oss" {
-  name               = azurerm_user_assigned_identity.lustre-oss.principal_id
-  scope              = data.azurerm_subscription.primary.id
-  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
-  principal_id       = azurerm_user_assigned_identity.lustre-oss.principal_id
-}
+# resource "azurerm_role_assignment" "lustre-oss" {
+#   name               = azurerm_user_assigned_identity.lustre-oss.principal_id
+#   scope              = data.azurerm_subscription.primary.id
+#   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.contributor.id}"
+#   principal_id       = azurerm_user_assigned_identity.lustre-oss.principal_id
+# }
 # (using this from keyvault.tf)
 #data "azurerm_client_config" "current" {}
 resource "azurerm_key_vault_access_policy" "lustre-oss" {

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -17,6 +17,9 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "primary" {}
+data "azurerm_client_config" "current" {}
+
 resource "random_string" "resource_postfix" {
   length = 8
   special = false

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -12,6 +12,11 @@ resource "azurerm_virtual_network" "azhop" {
   location            = azurerm_resource_group.rg[0].location
   address_space       = [try(local.configuration_yml["network"]["vnet"]["address_space"], "10.0.0.0/16")]
 }
+# Resource group of the existing vnet
+data "azurerm_resource_group" "rg_vnet" {
+  count    = local.create_vnet ? 0 : 1
+  name     = try(split("/", local.vnet_id)[4], "foo")
+}
 
 # Frontend Subnet
 data "azurerm_subnet" "frontend" {


### PR DESCRIPTION
- remove role assignement on Lustre and only set KV access policies
- use User Assign identity for Cycle
- Set contributor role for Cycle only on the RG azhop is deployed in
- Update documentation on how to use an SPN and which roles are needed
- fix an issue with access policies and reader when not specified
- move global resources in main.tf (subscription and client)

close #443 