### PR TITLE
enable AN on the OnDemand VM

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -43,7 +43,7 @@ ad:
   vm_size: Standard_D2s_v3
 # On demand VM configuration
 ondemand:
-  vm_size: Standard_D2s_v3
+  vm_size: Standard_D4s_v3
 # Grafana VM configuration
 grafana:
   vm_size: Standard_D2s_v3

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -48,7 +48,7 @@ ad:
   vm_size: Standard_D2s_v3
 # On demand VM configuration
 ondemand:
-  vm_size: Standard_D2s_v3
+  vm_size: Standard_D4s_v3
 # Scheduler VM configuration
 scheduler:
   vm_size: Standard_D2s_v3

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -10,6 +10,7 @@ resource "azurerm_network_interface" "ondemand-nic" {
   name                = "ondemand-nic"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  enable_accelerated_networking = true
 
   ip_configuration {
     name                          = "internal"
@@ -23,7 +24,7 @@ resource "azurerm_linux_virtual_machine" "ondemand" {
   name                = "ondemand"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
-  size                = try(local.configuration_yml["ondemand"].vm_size, "Standard_D2s_v3")
+  size                = try(local.configuration_yml["ondemand"].vm_size, "Standard_D4s_v3")
   admin_username      = local.admin_username
   network_interface_ids = [
     azurerm_network_interface.ondemand-nic.id,


### PR DESCRIPTION
close #437 

## Breaking Change
Deploying over an existing environment will fail because AN cannot be enabled on an existing VM. Delete the VM to workaround this issue.