### PR TITLE
Add extra tags on the Resource Group

### DIFF
--- a/.github/workflows/configs/integration.yml
+++ b/.github/workflows/configs/integration.yml
@@ -1,6 +1,9 @@
 ---
 location: westeurope
 resource_group: __RESOURCE_GROUP__
+tags:
+  env: dev
+  project: azhop
 homefs_size_tb: 4
 homefs_service_level: Standard
 admin_user: hpcadmin

--- a/.github/workflows/configs/production.yml
+++ b/.github/workflows/configs/production.yml
@@ -1,6 +1,9 @@
 ---
 location: southcentralus
 resource_group: azhop_production
+tags:
+  env: production
+  project: azhop
 homefs_size_tb: 8
 homefs_service_level: Premium
 admin_user: hpcadmin

--- a/.github/workflows/configs/validation.yml
+++ b/.github/workflows/configs/validation.yml
@@ -1,6 +1,9 @@
 ---
 location: westeurope
 resource_group: azhop_validation
+tags:
+  env: validation
+  project: azhop
 homefs_size_tb: 8
 homefs_service_level: Premium
 admin_user: hpcadmin

--- a/build.sh
+++ b/build.sh
@@ -96,12 +96,10 @@ fi
 
 # Get the current logged user
 azure_user=$(az account show --query user.name -o tsv)
-created_on=$(date -u)
 echo "terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 $PARAMS"
 
 terraform -chdir=$TF_FOLDER $TF_COMMAND -parallelism=30 \
   -var "CreatedBy=$azure_user" \
-  -var "CreatedOn=$created_on" \
   $PARAMS
 
 if [ -e $TF_FOLDER/terraform.tfstate ] && [ $TF_FOLDER != $THIS_DIR/tf ]; then

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -3,6 +3,10 @@
 location: westeurope
 # Name of the resource group to create all resources
 resource_group: azhop
+# Additional tags to be added on the Resource Group
+tags:
+  env: dev
+  project: azhop
 # Size of the ANF pool and unique volume
 homefs_size_tb: 4
 # Service level of the ANF volume, can be: Standard, Premium, Ultra

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -34,6 +34,9 @@ network:
       netapp:
         name: netapp
         address_prefixes: "10.0.2.0/24"
+      ad:
+        name: ad
+        address_prefixes: "10.0.3.0/28"
       compute:
         name: compute
         address_prefixes: "10.0.16.0/20"

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -39,6 +39,9 @@ network:
       netapp:
         name: netapp
         address_prefixes: "10.0.2.0/24"
+      ad:
+        name: ad
+        address_prefixes: "10.0.3.0/28"
       compute:
         name: compute
         address_prefixes: "10.0.16.0/20"

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -8,6 +8,10 @@ Here is a template for building such configuration file.
 location: westeurope
 # Name of the resource group to create all resources
 resource_group: azhop
+# Additional tags to be added on the Resource Group
+tags:
+  env: dev
+  project: azhop
 # Size of the ANF pool and unique volume
 homefs_size_tb: 4
 # Service level of the ANF volume, can be: Standard, Premium, Ultra

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -3,8 +3,8 @@
 - [How to use an existing VNET ?](#how-to-use-an-existing-vnet)
   - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
   - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
-  - [How to deploy ANF with Dual protocol ?](#how_to_deploy_anf_with_dual_protocol)
-  - [How to deploy in a locked down network environment ?](#deploy_in_a_locked_down_network_environment)
+  - [How to deploy ANF with Dual protocol ?](#how-to-deploy-anf-with-dual-protocol)
+  - [How to deploy in a locked down network environment ?](#deploy-in-a-locked-down-network-environment)
 
 ## How to use an existing VNET ?
 Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.
@@ -48,7 +48,7 @@ There is a way to easily create a standalone VNET for **azhop** without doing a 
 - Save your config file and create a new one in which you now specify the VNET ID created above
 - Build your **azhop** environment
 
-## How to deploy ANF with Dual protocol 
+## How to deploy ANF with Dual protocol
 When using Windows nodes you may want to use SMB to mount ANF volumes, as a result ANF need to be configure to use dual protocol and the ANF account need to be domain joined. This imply to break out the deployment in two main steps because the Active Directory need to be configured before provisioning ANF. Follow the steps below to deploy ANF with Dual Protocol enabled :
 
  - Dual protocol must be enabled in the configuration file with this value :

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -29,6 +29,8 @@ network:
         name: itonly
       netapp:
         name: storage
+      ad:
+        name: domaincontroler
       compute:
         name: dynamic
 ```
@@ -37,9 +39,7 @@ network:
 - There is a need of a minimum of 5 IP addresses for the infrastructure VMs
 - Allow enough IP addresses for the Lustre cluster, default being 4 : Robinhood + Lustre + 2*OSS
 - Delegate a subnet to Azure NetApp Files like documented [here](https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-delegate-subnet)
-- The *frontend* subnet needs to allow this traffic :
-  - HTTPS/443 In => this is used by the OnDemand web portal and all end users
-  - SSH/22 In => This is used when doing the deployment and by admins only
+- Look at the `tf/network_security_group.tf` and `tf/variables_local.tf` to get the list of all ports and rules define bewteen subnets
 
 ### Creating a standalone VNET for AZ-HOP
 There is a way to easily create a standalone VNET for **azhop** without doing a full deployment by following these steps :

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -35,7 +35,7 @@
       cc_password: '{{password.stdout}}'
       cc_storage: '{{global_cc_storage}}'
       cc_domain: '{{ad_join_domain}}'
-      cc_ad_server: '{{ad_dns}}'
+      cc_ad_server: '{{ldap_server}}'
       cc_rpms_jetpack: '{{ cyclecloud.rpms.jetpack | default(None) }}'
       cc_rpms_cycle: '{{ cyclecloud.rpms.cyclecloud | default(None) }}'
 

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -33,7 +33,7 @@
       grafana_fqdn: localhost
       grafana_admin_user: "{{admin_user}}"
       grafana_admin_password: "{{password.stdout}}"
-      grafana_ldap_server: "{{ad_dns}}"
+      grafana_ldap_server: "{{ldap_server}}"
       grafana_server_root_url: "%(protocol)s://%(domain)s:%(http_port)s/rnode/grafana/%(http_port)s/"
       grafana_auth_ldap_enabled: true
       grafana_public_facing_domain_name: localhost

--- a/tf/ad.tf
+++ b/tf/ad.tf
@@ -5,7 +5,7 @@ resource "azurerm_network_interface" "ad-nic" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = local.create_vnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
+    subnet_id                     = local.create_vnet ? azurerm_subnet.ad[0].id : data.azurerm_subnet.ad[0].id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -47,9 +47,13 @@ resource "azurerm_resource_group" "rg" {
   count    = local.create_rg ? 1 : 0
   name     = local.resource_group
   location = local.location
-  tags = {
-    CreatedBy = var.CreatedBy
-    CreatedOn = var.CreatedOn
+
+  tags = merge( local.common_tags, local.extra_tags)
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedOn"]
+    ]
   }
 }
 

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -74,6 +74,23 @@ resource "azurerm_subnet" "netapp" {
     }
   }
 }
+
+# ad subnet
+data "azurerm_subnet" "ad" {
+  count                = local.create_vnet ? 0 : 1
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["ad"]["name"], "ad")
+  resource_group_name  = try(split("/", local.vnet_id)[4], "foo")
+  virtual_network_name = try(split("/", local.vnet_id)[8], "foo")
+}
+
+resource "azurerm_subnet" "ad" {
+  count                = local.create_vnet ? 1 : 0
+  name                 = try(local.configuration_yml["network"]["vnet"]["subnets"]["ad"]["name"], "ad")
+  virtual_network_name = azurerm_virtual_network.azhop[count.index].name
+  resource_group_name  = azurerm_virtual_network.azhop[count.index].resource_group_name
+  address_prefixes     = [try(local.configuration_yml["network"]["vnet"]["subnets"]["ad"]["address_prefixes"], "10.0.3.0/28")]
+}
+
 # resource "azurerm_subnet" "bastion" {
 #  name                 = "AzureBastionSubnet"
 #  virtual_network_name = azurerm_virtual_network.azhop.name

--- a/tf/network/main.tf
+++ b/tf/network/main.tf
@@ -27,9 +27,12 @@ resource "azurerm_resource_group" "rg" {
   count    = local.create_rg ? 1 : 0
   name     = local.resource_group
   location = local.location
-  tags = {
-    CreatedBy = var.CreatedBy
-    CreatedOn = var.CreatedOn
+  tags = merge( local.common_tags, local.extra_tags)
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedOn"]
+    ]
   }
 }
 

--- a/tf/network_security_group.tf
+++ b/tf/network_security_group.tf
@@ -1360,6 +1360,30 @@ resource "azurerm_network_security_group" "ad" {
   }
 
   security_rule {
+        name                       = "AllowAdServerNetappOutTcp"
+        priority                   = "150"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_address_prefixes = azurerm_subnet.netapp[0].address_prefixes
+  }
+
+  security_rule {
+        name                       = "AllowAdServerNetappOutUdp"
+        priority                   = "160"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_address_prefixes = azurerm_subnet.netapp[0].address_prefixes
+  }
+
+  security_rule {
         name                       = "AllowInternetOutBound"
         priority                   = "3000"
         direction                  = "Outbound"

--- a/tf/network_security_group.tf
+++ b/tf/network_security_group.tf
@@ -403,17 +403,17 @@ resource "azurerm_network_security_group" "admin" {
         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ssh"].id]
   }
 
-  security_rule {
-        name                       = "AllowRdpIn"
-        priority                   = "110"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["Rdp"]
-        source_application_security_group_ids  = [azurerm_application_security_group.asg["asg-jumpbox"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowRdpIn"
+#         priority                   = "110"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["Rdp"]
+#         source_application_security_group_ids  = [azurerm_application_security_group.asg["asg-jumpbox"].id]
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
   security_rule {
         name                       = "AllowAdServerInTcp"
@@ -423,33 +423,33 @@ resource "azurerm_network_security_group" "admin" {
         protocol                   = "tcp"
         source_port_range          = "*"
         destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad-client"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
   }
 
-  security_rule {
-        name                       = "AllowAdServerInComputeTcp"
-        priority                   = "130"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
-        source_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerInComputeTcp"
+#         priority                   = "130"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+#         source_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
-  security_rule {
-        name                       = "AllowAdServerInNetAppTcp"
-        priority                   = "140"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
-        source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerInNetAppTcp"
+#         priority                   = "140"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+#         source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
   security_rule {
         name                       = "AllowAdServerInUdp"
@@ -459,33 +459,33 @@ resource "azurerm_network_security_group" "admin" {
         protocol                   = "udp"
         source_port_range          = "*"
         destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad-client"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
   }
 
-  security_rule {
-        name                       = "AllowAdServerInComputeUdp"
-        priority                   = "160"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "udp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
-        source_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerInComputeUdp"
+#         priority                   = "160"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "udp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+#         source_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
-  security_rule {
-        name                       = "AllowAdServerInNetAppUdp"
-        priority                   = "170"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "udp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
-        source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerInNetAppUdp"
+#         priority                   = "170"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "udp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+#         source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
   security_rule {
         name                       = "AllowTelegrafIn"
@@ -619,17 +619,17 @@ resource "azurerm_network_security_group" "admin" {
         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-robinhood"].id]
   }
 
-  security_rule {
-        name                       = "AllowSocksIn"
-        priority                   = "290"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["Socks"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-jumpbox"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
-  }
+#   security_rule {
+#         name                       = "AllowSocksIn"
+#         priority                   = "290"
+#         direction                  = "Inbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["Socks"]
+#         source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-jumpbox"].id]
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+#   }
 
   # security_rule {
   #       name                       = "AllowOnDemandToAd"
@@ -658,17 +658,17 @@ resource "azurerm_network_security_group" "admin" {
   #
   #         OUTBOUND
   #
-  security_rule {
-        name                       = "AllowAdServerOutTcp"
-        priority                   = "100"
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerOutTcp"
+#         priority                   = "100"
+#         direction                  = "Outbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+#         source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
+#   }
 
   security_rule {
         name                       = "AllowAdClientOutTcp"
@@ -682,29 +682,29 @@ resource "azurerm_network_security_group" "admin" {
         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
   }
 
-  security_rule {
-        name                       = "AllowAdServerComputeOutTcp"
-        priority                   = "120"
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
-        destination_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
-  }
+#   security_rule {
+#         name                       = "AllowAdServerComputeOutTcp"
+#         priority                   = "120"
+#         direction                  = "Outbound"
+#         access                     = "Allow"
+#         protocol                   = "tcp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+#         source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+#         destination_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
+#   }
 
-  security_rule {
-        name                       = "AllowAdServerOutUdp"
-        priority                   = "130"
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "udp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
-        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
-  }
+#   security_rule {
+#         name                       = "AllowAdServerOutUdp"
+#         priority                   = "130"
+#         direction                  = "Outbound"
+#         access                     = "Allow"
+#         protocol                   = "udp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+#         source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+#         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
+#   }
 
   security_rule {
         name                       = "AllowAdClientOutUdp"
@@ -718,17 +718,17 @@ resource "azurerm_network_security_group" "admin" {
         destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
   }
 
-  security_rule {
-        name                       = "AllowAdServerComputeOutUdp"
-        priority                   = "150"
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "udp"
-        source_port_range          = "*"
-        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
-        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
-        destination_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
-  }
+#   security_rule {
+#         name                       = "AllowAdServerComputeOutUdp"
+#         priority                   = "150"
+#         direction                  = "Outbound"
+#         access                     = "Allow"
+#         protocol                   = "udp"
+#         source_port_range          = "*"
+#         destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+#         source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+#         destination_address_prefixes    = azurerm_subnet.compute[0].address_prefixes
+#   }
 
   security_rule {
         name                       = "AllowDnsOut"
@@ -1171,11 +1171,223 @@ resource "azurerm_network_security_group" "compute" {
   }
 }
 
-
 resource "azurerm_subnet_network_security_group_association" "compute" {
   count                     = local.create_vnet ? 1 : 0
   subnet_id                 = azurerm_subnet.compute[count.index].id
   network_security_group_id = azurerm_network_security_group.compute[count.index].id
+}
+
+# Network security group for the ad subnet
+resource "azurerm_network_security_group" "ad" {
+  count                = local.create_vnet ? 1 : 0
+  name                = "nsg-${local.create_vnet ? azurerm_subnet.ad[0].name : data.azurerm_subnet.ad[0].name}"
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+
+  #
+  #         INBOUND
+  #
+  security_rule {
+        name                       = "AllowAdServerInTcp"
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad-client"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerInUdp"
+        priority                   = "110"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad-client"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerComputeInTcp"
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_address_prefixes = azurerm_subnet.compute[0].address_prefixes
+        destination_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerComputeInUdp"
+        priority                   = "130"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_address_prefixes = azurerm_subnet.compute[0].address_prefixes
+        destination_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowSocksIn"
+        priority                   = "140"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["Socks"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-jumpbox"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerInNetAppUdp"
+        priority                   = "150"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerInNetAppTcp"
+        priority                   = "160"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_address_prefixes    = azurerm_subnet.netapp[0].address_prefixes
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "AllowRdpIn"
+        priority                   = "170"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["Rdp"]
+        source_application_security_group_ids  = [azurerm_application_security_group.asg["asg-jumpbox"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad"].id]
+  }
+
+  security_rule {
+        name                       = "DenyVnetInbound"
+        priority                   = "3100"
+        direction                  = "Inbound"
+        access                     = "Deny"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "VirtualNetwork"
+  }
+
+
+  #
+  #         OUTBOUND
+  #
+  security_rule {
+        name                       = "AllowAdServerOutTcp"
+        priority                   = "100"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
+  }
+
+  security_rule {
+        name                       = "AllowAdServerOutUdp"
+        priority                   = "110"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_application_security_group_ids = [azurerm_application_security_group.asg["asg-ad-client"].id]
+  }
+
+  security_rule {
+        name                       = "AllowDnsOut"
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["Dns"]
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "VirtualNetwork"
+  }
+
+  security_rule {
+        name                       = "AllowAdServerComputeOutTcp"
+        priority                   = "130"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerTcp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_address_prefixes = azurerm_subnet.compute[0].address_prefixes
+  }
+
+  security_rule {
+        name                       = "AllowAdServerComputeOutUdp"
+        priority                   = "140"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_ranges    = local.nsg_destination_ports["DomainControlerUdp"]
+        source_application_security_group_ids      = [azurerm_application_security_group.asg["asg-ad"].id]
+        destination_address_prefixes = azurerm_subnet.compute[0].address_prefixes
+  }
+
+  security_rule {
+        name                       = "AllowInternetOutBound"
+        priority                   = "3000"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "Internet"
+  }
+
+  security_rule {
+        name                       = "DenyVnetOutBound"
+        priority                   = "3100"
+        direction                  = "Outbound"
+        access                     = "Deny"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "VirtualNetwork"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "ad" {
+  count                     = local.create_vnet ? 1 : 0
+  subnet_id                 = azurerm_subnet.ad[count.index].id
+  network_security_group_id = azurerm_network_security_group.ad[count.index].id
 }
 
 # NSG cannot be applied on a delegated subnet for Azure Netapp files https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-delegate-subnet

--- a/tf/templates/global_variables.tmpl
+++ b/tf/templates/global_variables.tmpl
@@ -5,6 +5,7 @@ global_config_file            : ${config_file}
 ad_dns                        : ${ad-ip}
 ad_join_user                  : ${admin_username}
 ad_join_domain                : hpc.azure
+ldap_server                   : ad
 anf_home_ip                   : ${ anf-home-ip }
 anf_home_path                 : ${ anf-home-path }
 ondemand_fqdn                 : ${ ondemand-fqdn }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,7 +1,3 @@
 variable CreatedBy {
   default = ""
 }
-
-variable CreatedOn {
-   default = ""
-}

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -9,6 +9,12 @@ locals {
     # Load parameters from the configuration file
     location = local.configuration_yml["location"]
     resource_group = local.configuration_yml["resource_group"]
+    extra_tags = try(local.configuration_yml["tags"], null)
+    common_tags = {
+        CreatedBy = var.CreatedBy
+        CreatedOn = timestamp()
+    }
+
     # Create the RG if creating a VNET or when reusing a VNET in another resource group
     create_rg = local.create_vnet || try(split("/", local.vnet_id)[4], local.resource_group) != local.resource_group
 


### PR DESCRIPTION
- allow extra tags to be added from the configuration file onto the resource group created
- avoid updating the CreatedOn tag
- remove the CreatedOn variable and use timestamp() instead
- merged with AD subnet

close #484 