### PR TITLE
Allow a no public IP deployment

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -51,6 +51,7 @@ network:
 # locked_down_network: 
 #   enforce: true
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
+#   public_ip: true # Disable public IP creation for Jumpbox, OnDemand and create images. Default to false
 # Active directory VM configuration
 ad:
   vm_size: Standard_D2s_v3

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -51,7 +51,7 @@ network:
 # locked_down_network: 
 #   enforce: true
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
-#   public_ip: true # Disable public IP creation for Jumpbox, OnDemand and create images. Default to false
+#   public_ip: true # Enable public IP creation for Jumpbox, OnDemand and create images. Default to true
 # Active directory VM configuration
 ad:
   vm_size: Standard_D2s_v3

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -56,6 +56,7 @@ network:
 # locked_down_network: 
 #   enforce: true
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
+#   public_ip: true # Disable public IP creation for Jumpbox, OnDemand and create images. Default to false
 # Active directory VM configuration
 ad:
   vm_size: Standard_D2s_v3

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -56,7 +56,7 @@ network:
 # locked_down_network: 
 #   enforce: true
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
-#   public_ip: true # Disable public IP creation for Jumpbox, OnDemand and create images. Default to false
+#   public_ip: true # Enable public IP creation for Jumpbox, OnDemand and create images. Default to true
 # Active directory VM configuration
 ad:
   vm_size: Standard_D2s_v3

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -5,6 +5,7 @@
   - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
   - [How to deploy ANF with Dual protocol ?](#how-to-deploy-anf-with-dual-protocol)
   - [How to deploy in a locked down network environment ?](#deploy-in-a-locked-down-network-environment)
+  - [Disable Public IP scenario](#disable-public-ip-scenario)
 
 ## How to use an existing VNET ?
 Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.
@@ -91,3 +92,14 @@ locked_down_network:
   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from.
 ```
 
+### Disable Public IP scenario
+To deploy `az-hop` in a no public IP scenario you have to set the `locked_down_network:public_ip` value to `false`. The default value being `true`.
+
+```yml
+locked_down_network: 
+  public_ip: false
+```
+
+In such scenario you need to use a `deployer` VM, make sure that this VM can access the `jumpbox` over SSH and the keyvault created. 
+
+> Note: One option is to provision that VM in the `admin` subnet and open an NSG rule for allowing SSH from that machine to the `jumbox`.

--- a/packer/azhop-centos79-v2-rdma-gpgpu.json
+++ b/packer/azhop-centos79-v2-rdma-gpgpu.json
@@ -16,7 +16,11 @@
             "vm_size": "Standard_d8s_v3",
             "managed_image_storage_account_type": "Premium_LRS",
             "ssh_pty": "true",
-            "build_resource_group_name": "{{user `var_resource_group`}}"
+            "build_resource_group_name": "{{user `var_resource_group`}}",
+            "private_virtual_network_with_public_ip": "{{user `var_private_virtual_network_with_public_ip`}}",
+            "virtual_network_name": "{{user `var_virtual_network_name`}}",
+            "virtual_network_subnet_name": "{{user `var_virtual_network_subnet_name`}}",
+            "virtual_network_resource_group_name": "{{user `var_virtual_network_resource_group_name`}}"
         }
     ],
     "provisioners": [

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -23,6 +23,13 @@ if [ $# -lt 2 ]; then
   exit 1
 fi
 
+nopip=$(yq eval .locked_down_network.public_ip $CONFIG_FILE)
+if [ "$nopip" == "false" ]; then
+  OPTIONS_FILE=options_nopip.json
+else
+  OPTIONS_FILE=options.json
+fi
+
 PACKER_OPTIONS="-timestamp-ui"
 while (( "$#" )); do
   case "${1}" in

--- a/packer/centos-7.8-desktop-3d.json
+++ b/packer/centos-7.8-desktop-3d.json
@@ -15,7 +15,11 @@
             "os_type": "Linux",
             "vm_size": "Standard_NV6",
             "ssh_pty": "true",
-            "build_resource_group_name": "{{user `var_resource_group`}}"
+            "build_resource_group_name": "{{user `var_resource_group`}}",
+            "private_virtual_network_with_public_ip": "{{user `var_private_virtual_network_with_public_ip`}}",
+            "virtual_network_name": "{{user `var_virtual_network_name`}}",
+            "virtual_network_subnet_name": "{{user `var_virtual_network_subnet_name`}}",
+            "virtual_network_resource_group_name": "{{user `var_virtual_network_resource_group_name`}}"
         }
     ],
     "provisioners": [

--- a/packer/templates/options.json.tmpl
+++ b/packer/templates/options.json.tmpl
@@ -2,5 +2,9 @@
   "var_subscription_id": "${subscription_id}",
   "var_resource_group": "${resource_group}",
   "var_location": "${location}",
-  "var_sig_name": "${sig_name}"
+  "var_sig_name": "${sig_name}",
+  "var_private_virtual_network_with_public_ip": "${private_virtual_network_with_public_ip}",
+  "var_virtual_network_name": "${virtual_network_name}",
+  "var_virtual_network_subnet_name": "${virtual_network_subnet_name}",
+  "var_virtual_network_resource_group_name": "${virtual_network_resource_group_name}"
 }

--- a/packer/templates/options.json.tmpl
+++ b/packer/templates/options.json.tmpl
@@ -2,9 +2,5 @@
   "var_subscription_id": "${subscription_id}",
   "var_resource_group": "${resource_group}",
   "var_location": "${location}",
-  "var_sig_name": "${sig_name}",
-  "var_private_virtual_network_with_public_ip": "${private_virtual_network_with_public_ip}",
-  "var_virtual_network_name": "${virtual_network_name}",
-  "var_virtual_network_subnet_name": "${virtual_network_subnet_name}",
-  "var_virtual_network_resource_group_name": "${virtual_network_resource_group_name}"
+  "var_sig_name": "${sig_name}"
 }

--- a/packer/templates/options_nopip.json.tmpl
+++ b/packer/templates/options_nopip.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "var_subscription_id": "${subscription_id}",
+  "var_resource_group": "${resource_group}",
+  "var_location": "${location}",
+  "var_sig_name": "${sig_name}",
+  "var_private_virtual_network_with_public_ip": "${private_virtual_network_with_public_ip}",
+  "var_virtual_network_name": "${virtual_network_name}",
+  "var_virtual_network_subnet_name": "${virtual_network_subnet_name}",
+  "var_virtual_network_resource_group_name": "${virtual_network_resource_group_name}"
+}

--- a/tf/active_directory/outputs.tf
+++ b/tf/active_directory/outputs.tf
@@ -1,7 +1,7 @@
 resource "local_file" "AnsibleInventory" { 
   content = templatefile("${local.playbooks_template_dir}/inventory.tmpl",
    {
-      jumpbox-pip       = azurerm_public_ip.jumpbox-pip.ip_address
+      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username
       ad-ip             = azurerm_network_interface.ad-nic.private_ip_address
       ad-passwd         = azurerm_windows_virtual_machine.ad.admin_password

--- a/tf/active_directory/outputs.tf
+++ b/tf/active_directory/outputs.tf
@@ -1,7 +1,7 @@
 resource "local_file" "AnsibleInventory" { 
   content = templatefile("${local.playbooks_template_dir}/inventory.tmpl",
    {
-      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
+      jumpbox-pip       = local.allow_public_ip ? azurerm_public_ip.jumpbox-pip[0].ip_address : azurerm_network_interface.jumpbox-nic.private_ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username
       ad-ip             = azurerm_network_interface.ad-nic.private_ip_address
       ad-passwd         = azurerm_windows_virtual_machine.ad.admin_password

--- a/tf/jumpbox.tf
+++ b/tf/jumpbox.tf
@@ -1,5 +1,5 @@
 resource "azurerm_public_ip" "jumpbox-pip" {
-  count               = local.locked_down_public_ip ? 0 : 1
+  count               = local.allow_public_ip ? 1 : 0
   name                = "jumpbox-pip"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
@@ -15,7 +15,7 @@ resource "azurerm_network_interface" "jumpbox-nic" {
     name                          = "internal"
     subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = local.locked_down_public_ip ? null : azurerm_public_ip.jumpbox-pip[0].id
+    public_ip_address_id          = local.allow_public_ip ? azurerm_public_ip.jumpbox-pip[0].id : null
   }
 }
 

--- a/tf/jumpbox.tf
+++ b/tf/jumpbox.tf
@@ -1,4 +1,5 @@
 resource "azurerm_public_ip" "jumpbox-pip" {
+  count               = local.locked_down_public_ip ? 0 : 1
   name                = "jumpbox-pip"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
@@ -14,7 +15,7 @@ resource "azurerm_network_interface" "jumpbox-nic" {
     name                          = "internal"
     subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = azurerm_public_ip.jumpbox-pip.id
+    public_ip_address_id          = local.locked_down_public_ip ? null : azurerm_public_ip.jumpbox-pip[0].id
   }
 }
 

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -1,4 +1,5 @@
 resource "azurerm_public_ip" "ondemand-pip" {
+  count               = local.locked_down_public_ip ? 0 : 1
   name                = "ondemand-pip"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
@@ -16,7 +17,7 @@ resource "azurerm_network_interface" "ondemand-nic" {
     name                          = "internal"
     subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = azurerm_public_ip.ondemand-pip.id
+    public_ip_address_id          = local.locked_down_public_ip ? null : azurerm_public_ip.ondemand-pip[0].id
   }
 }
 

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -1,5 +1,5 @@
 resource "azurerm_public_ip" "ondemand-pip" {
-  count               = local.locked_down_public_ip ? 0 : 1
+  count               = local.allow_public_ip ? 1 : 0
   name                = "ondemand-pip"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
@@ -17,7 +17,7 @@ resource "azurerm_network_interface" "ondemand-nic" {
     name                          = "internal"
     subnet_id                     = local.create_vnet ? azurerm_subnet.frontend[0].id : data.azurerm_subnet.frontend[0].id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = local.locked_down_public_ip ? null : azurerm_public_ip.ondemand-pip[0].id
+    public_ip_address_id          = local.allow_public_ip ? azurerm_public_ip.ondemand-pip[0].id : null
   }
 }
 

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -74,7 +74,7 @@ resource "local_file" "packer" {
       sig_name        = azurerm_shared_image_gallery.sig.name
       private_virtual_network_with_public_ip = local.allow_public_ip
       virtual_network_name                   = local.create_vnet ? azurerm_virtual_network.azhop[0].name : data.azurerm_virtual_network.azhop[0].name
-      virtual_network_subnet_name            = local.create_vnet ? azurerm_subnet.admin[0].name : data.local.create_vnet ? azurerm_subnet.admin[0].name
+      virtual_network_subnet_name            = local.create_vnet ? azurerm_subnet.admin[0].name : data.azurerm_subnet.admin[0].name
       virtual_network_resource_group_name    = local.create_vnet ? azurerm_virtual_network.azhop[0].resource_group_name : data.azurerm_virtual_network.azhop[0].resource_group_name
     }
   )

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -65,8 +65,20 @@ resource "local_file" "get_secret_script" {
   file_permission = 0755
 }
 
-resource "local_file" "packer" {
+resource "local_file" "packer_pip" {
   content = templatefile("${local.packer_root_dir}/templates/options.json.tmpl",
+    {
+      subscription_id = data.azurerm_subscription.primary.subscription_id
+      resource_group  = local.resource_group
+      location        = local.location
+      sig_name        = azurerm_shared_image_gallery.sig.name
+    }
+  )
+  filename = "${local.packer_root_dir}/options.json"
+}
+
+resource "local_file" "packer_nopip" {
+  content = templatefile("${local.packer_root_dir}/templates/options_nopip.json.tmpl",
     {
       subscription_id = data.azurerm_subscription.primary.subscription_id
       resource_group  = local.resource_group
@@ -78,6 +90,5 @@ resource "local_file" "packer" {
       virtual_network_resource_group_name    = local.create_vnet ? azurerm_virtual_network.azhop[0].resource_group_name : data.azurerm_virtual_network.azhop[0].resource_group_name
     }
   )
-  filename = "${local.packer_root_dir}/options.json"
+  filename = "${local.packer_root_dir}/options_nopip.json"
 }
-

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -1,11 +1,11 @@
 resource "local_file" "AnsibleInventory" { 
   content = templatefile("${local.playbooks_template_dir}/inventory.tmpl",
    {
-      jumpbox-pip       = azurerm_public_ip.jumpbox-pip.ip_address
+      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username
       scheduler-ip      = azurerm_network_interface.scheduler-nic.private_ip_address
       scheduler-user    = azurerm_linux_virtual_machine.scheduler.admin_username
-      ondemand-ip      = azurerm_network_interface.ondemand-nic.private_ip_address
+      ondemand-ip       = azurerm_network_interface.ondemand-nic.private_ip_address
       ondemand-user     = azurerm_linux_virtual_machine.ondemand.admin_username
       ccportal-ip       = azurerm_network_interface.ccportal-nic.private_ip_address
       grafana-ip        = azurerm_network_interface.grafana-nic.private_ip_address
@@ -32,7 +32,7 @@ resource "local_file" "global_variables" {
       ad-ip               = azurerm_network_interface.ad-nic.private_ip_address
       anf-home-ip         = element(azurerm_netapp_volume.home.mount_ip_addresses, 0)
       anf-home-path       = azurerm_netapp_volume.home.volume_path
-      ondemand-fqdn       = azurerm_public_ip.ondemand-pip.fqdn
+      ondemand-fqdn       = local.locked_down_public_ip ? azurerm_network_interface.ondemand-nic.private_ip_address : azurerm_public_ip.ondemand-pip[0].fqdn
       subscription_id     = data.azurerm_subscription.primary.subscription_id
       key_vault           = azurerm_key_vault.azhop.name
       sig_name            = azurerm_shared_image_gallery.sig.name
@@ -47,7 +47,7 @@ resource "local_file" "global_variables" {
 resource "local_file" "connect_script" {
   sensitive_content = templatefile("${local.playbooks_template_dir}/connect.tmpl",
     {
-      jumpbox-pip       = azurerm_public_ip.jumpbox-pip.ip_address,
+      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username,
     }
   )
@@ -77,6 +77,3 @@ resource "local_file" "packer" {
   filename = "${local.packer_root_dir}/options.json"
 }
 
-output "ondemand_fqdn" {
-  value = azurerm_public_ip.ondemand-pip.fqdn
-}

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -1,7 +1,7 @@
 resource "local_file" "AnsibleInventory" { 
   content = templatefile("${local.playbooks_template_dir}/inventory.tmpl",
    {
-      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
+      jumpbox-pip       = local.allow_public_ip ? azurerm_public_ip.jumpbox-pip[0].ip_address : azurerm_network_interface.jumpbox-nic.private_ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username
       scheduler-ip      = azurerm_network_interface.scheduler-nic.private_ip_address
       scheduler-user    = azurerm_linux_virtual_machine.scheduler.admin_username
@@ -32,7 +32,7 @@ resource "local_file" "global_variables" {
       ad-ip               = azurerm_network_interface.ad-nic.private_ip_address
       anf-home-ip         = element(azurerm_netapp_volume.home.mount_ip_addresses, 0)
       anf-home-path       = azurerm_netapp_volume.home.volume_path
-      ondemand-fqdn       = local.locked_down_public_ip ? azurerm_network_interface.ondemand-nic.private_ip_address : azurerm_public_ip.ondemand-pip[0].fqdn
+      ondemand-fqdn       = local.allow_public_ip ? azurerm_public_ip.ondemand-pip[0].fqdn : azurerm_network_interface.ondemand-nic.private_ip_address
       subscription_id     = data.azurerm_subscription.primary.subscription_id
       key_vault           = azurerm_key_vault.azhop.name
       sig_name            = azurerm_shared_image_gallery.sig.name
@@ -47,7 +47,7 @@ resource "local_file" "global_variables" {
 resource "local_file" "connect_script" {
   sensitive_content = templatefile("${local.playbooks_template_dir}/connect.tmpl",
     {
-      jumpbox-pip       = local.locked_down_public_ip ? azurerm_network_interface.jumpbox-nic.private_ip_address : azurerm_public_ip.jumpbox-pip[0].ip_address
+      jumpbox-pip       = local.allow_public_ip ? azurerm_public_ip.jumpbox-pip[0].ip_address :  azurerm_network_interface.jumpbox-nic.private_ip_address
       jumpbox-user      = azurerm_linux_virtual_machine.jumpbox.admin_username,
     }
   )

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -72,6 +72,10 @@ resource "local_file" "packer" {
       resource_group  = local.resource_group
       location        = local.location
       sig_name        = azurerm_shared_image_gallery.sig.name
+      private_virtual_network_with_public_ip = local.allow_public_ip
+      virtual_network_name                   = local.create_vnet ? azurerm_virtual_network.azhop[0].name : data.azurerm_virtual_network.azhop[0].name
+      virtual_network_subnet_name            = local.create_vnet ? azurerm_subnet.admin[0].name : data.local.create_vnet ? azurerm_subnet.admin[0].name
+      virtual_network_resource_group_name    = local.create_vnet ? azurerm_virtual_network.azhop[0].resource_group_name : data.azurerm_virtual_network.azhop[0].resource_group_name
     }
   )
   filename = "${local.packer_root_dir}/options.json"

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -46,7 +46,7 @@ locals {
     # Lockdown scenario
     locked_down_network = try(local.configuration_yml["locked_down_network"]["enforce"], false)
     grant_access_from   = try(local.configuration_yml["locked_down_network"]["grant_access_from"], [])
-    locked_down_public_ip = try(local.configuration_yml["locked_down_network"]["public_ip"], false)
+    allow_public_ip = try(local.configuration_yml["locked_down_network"]["public_ip"], true)
 
 
     # Application Security Groups

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -46,6 +46,8 @@ locals {
     # Lockdown scenario
     locked_down_network = try(local.configuration_yml["locked_down_network"]["enforce"], false)
     grant_access_from   = try(local.configuration_yml["locked_down_network"]["grant_access_from"], [])
+    locked_down_public_ip = try(local.configuration_yml["locked_down_network"]["public_ip"], false)
+
 
     # Application Security Groups
     default_asgs = ["asg-ssh", "asg-rdp", "asg-jumpbox", "asg-ad", "asg-ad-client", "asg-lustre", "asg-lustre-client", "asg-pbs", "asg-pbs-client", "asg-cyclecloud", "asg-cyclecloud-client", "asg-nfs-client", "asg-telegraf", "asg-grafana", "asg-robinhood", "asg-ondemand", "asg-chrony"]


### PR DESCRIPTION
- remove public IP for jumpbox and ondemand
- deploy packer VM in the admin subnet with no PIP
- set on-demand fqdn to private IP if deploying with no PIP
- documentation

close #489 
close #492 