### PR TITLE
use an existing NFS server for the users home directory

### DIFF
--- a/.github/workflows/deploy_full.yml
+++ b/.github/workflows/deploy_full.yml
@@ -79,7 +79,7 @@ jobs:
 
           set +e
           build_error=0
-          ./build.sh -a apply -f ./tf
+          ./build.sh -a apply
           build_error=$?
           ./azhop_state.sh upload ${{ env.AZHOP_STATE_ACCOUNT }} ${{ env.AZHOP_STATE_CONTAINER }}
           set -e

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -7,14 +7,23 @@ resource_group: azhop
 tags:
   env: dev
   project: azhop
-# Size of the ANF pool and unique volume
-homefs_size_tb: 4
-# Service level of the ANF volume, can be: Standard, Premium, Ultra
-homefs_service_level: Standard
-# name of the homedir on the ANF volume
-homedir_mountpoint: /anfhome
-# dual protocol
-dual_protocol: false # true to enable SMB support. false by default
+# Define an ANF account, single pool and volume
+# If not present assume that there is an existing NFS share for the users home directory
+anf:
+  # Size of the ANF pool and unique volume
+  homefs_size_tb: 4
+  # Service level of the ANF volume, can be: Standard, Premium, Ultra
+  homefs_service_level: Standard
+  # dual protocol
+  dual_protocol: false # true to enable SMB support. false by default
+
+mounts:
+  # mount settings for the user home directory
+  home:
+    mountpoint: /anfhome
+    server: '{{anf_home_ip}}' # Specify an existing NFS server name or IP, when using the ANF built in use '{{anf_home_ip}}'
+    export: '{{anf_home_path}}' # Specify an existing NFS export directory, when using the ANF built in use '{{anf_home_path}}'
+
 # name of the admin account
 admin_user: hpcadmin
 # Object ID to grant key vault read access

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -20,7 +20,7 @@ anf:
 mounts:
   # mount settings for the user home directory
   home:
-    mountpoint: /anfhome
+    mountpoint: /anfhome # /sharedhome for example
     server: '{{anf_home_ip}}' # Specify an existing NFS server name or IP, when using the ANF built in use '{{anf_home_ip}}'
     export: '{{anf_home_path}}' # Specify an existing NFS export directory, when using the ANF built in use '{{anf_home_path}}'
 

--- a/playbooks/linux.yml
+++ b/playbooks/linux.yml
@@ -58,7 +58,7 @@
   - name: Read Password from KV
     command: az keyvault secret show --vault-name {{key_vault}} -n {{admin_user}}-password --query "value" -o tsv
     delegate_to: localhost
-    connection: local
+#    connection: local
     register: ad_join_password
     become: false
     run_once: true

--- a/tf/anf.tf
+++ b/tf/anf.tf
@@ -1,4 +1,5 @@
 resource "azurerm_netapp_account" "azhop" {
+  count = local.create_anf ? 1 : 0
   name                = "azhop-${random_string.resource_postfix.result}"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
@@ -21,10 +22,11 @@ resource "azurerm_netapp_account" "azhop" {
 }
 
 resource "azurerm_netapp_pool" "anfpool" {
+  count = local.create_anf ? 1 : 0
   name                = "anfpool-${random_string.resource_postfix.result}"
-  account_name        = azurerm_netapp_account.azhop.name
-  location            = azurerm_netapp_account.azhop.location
-  resource_group_name = azurerm_netapp_account.azhop.resource_group_name
+  account_name        = azurerm_netapp_account.azhop[0].name
+  location            = azurerm_netapp_account.azhop[0].location
+  resource_group_name = azurerm_netapp_account.azhop[0].resource_group_name
   service_level       = local.homefs_service_level
   size_in_tb          = local.homefs_size_tb
   lifecycle {
@@ -34,11 +36,12 @@ resource "azurerm_netapp_pool" "anfpool" {
   }
 }
 resource "azurerm_netapp_volume" "home" {
+  count = local.create_anf ? 1 : 0
   name                = "anfhome"
-  location            = azurerm_netapp_account.azhop.location
-  resource_group_name = azurerm_netapp_account.azhop.resource_group_name
-  account_name        = azurerm_netapp_account.azhop.name
-  pool_name           = azurerm_netapp_pool.anfpool.name
+  location            = azurerm_netapp_account.azhop[0].location
+  resource_group_name = azurerm_netapp_account.azhop[0].resource_group_name
+  account_name        = azurerm_netapp_account.azhop[0].name
+  pool_name           = azurerm_netapp_pool.anfpool[0].name
   volume_path         = "home-${random_string.resource_postfix.result}"
   service_level       = local.homefs_service_level
   subnet_id           = local.create_vnet ? azurerm_subnet.netapp[0].id : data.azurerm_subnet.netapp[0].id

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -30,8 +30,8 @@ resource "local_file" "global_variables" {
       config_file         = local.configuration_file
       homedir_mountpoint  = local.homedir_mountpoint
       ad-ip               = azurerm_network_interface.ad-nic.private_ip_address
-      anf-home-ip         = element(azurerm_netapp_volume.home.mount_ip_addresses, 0)
-      anf-home-path       = azurerm_netapp_volume.home.volume_path
+      anf-home-ip         = local.create_anf ? element(azurerm_netapp_volume.home[0].mount_ip_addresses, 0) : local.configuration_yml["mounts"]["home"]["server"]
+      anf-home-path       = local.create_anf ? azurerm_netapp_volume.home[0].volume_path : local.configuration_yml["mounts"]["home"]["export"]
       ondemand-fqdn       = local.allow_public_ip ? azurerm_public_ip.ondemand-pip[0].fqdn : azurerm_network_interface.ondemand-nic.private_ip_address
       subscription_id     = data.azurerm_subscription.primary.subscription_id
       key_vault           = azurerm_key_vault.azhop.name

--- a/tf/templates/global_variables.tmpl
+++ b/tf/templates/global_variables.tmpl
@@ -6,12 +6,13 @@ ad_dns                        : ${ad-ip}
 ad_join_user                  : ${admin_username}
 ad_join_domain                : hpc.azure
 ldap_server                   : ad
-anf_home_ip                   : ${ anf-home-ip }
-anf_home_path                 : ${ anf-home-path }
-ondemand_fqdn                 : ${ ondemand-fqdn }
+anf_home_ip                   : ${anf-home-ip}
+homedir_mountpoint            : ${homedir_mountpoint}
+anf_home_path                 : ${anf-home-path}
+ondemand_fqdn                 : ${ondemand-fqdn}
 ansible_ssh_private_key_file  : ${admin_username}_id_rsa
 subscription_id               : ${subscription_id}
 key_vault                     : ${key_vault}
 sig_name                      : ${sig_name}
-lustre_hsm_storage_account    : ${ lustre_hsm_storage_account }
-lustre_hsm_storage_container  : ${ lustre_hsm_storage_container }
+lustre_hsm_storage_account    : ${lustre_hsm_storage_account}
+lustre_hsm_storage_container  : ${lustre_hsm_storage_container}

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -19,10 +19,13 @@ locals {
     create_rg = local.create_vnet || try(split("/", local.vnet_id)[4], local.resource_group) != local.resource_group
 
     # ANF
-    homefs_size_tb = try(local.configuration_yml["homefs_size_tb"], 4)
-    homefs_service_level = try(local.configuration_yml["homefs_service_level"], "Standard")
-    anf_dual_protocol = try(local.configuration_yml["dual_protocol"], false)
-    homedir_mountpoint = try(local.configuration_yml["homedir_mountpoint"], "/anfhome")
+    create_anf = try(local.configuration_yml["anf"], false) || try(local.configuration_yml["homefs_size_tb"] > 0, false)
+
+    homefs_size_tb = try(local.configuration_yml["anf"]["homefs_size_tb"], try(local.configuration_yml["homefs_size_tb"], 4))
+    homefs_service_level = try(local.configuration_yml["anf"]["homefs_service_level"], try(local.configuration_yml["homefs_service_level"], "Standard"))
+    anf_dual_protocol = try(local.configuration_yml["anf"]["dual_protocol"], try(local.configuration_yml["dual_protocol"], false))
+
+    homedir_mountpoint = try(local.configuration_yml["mounts"]["home"]["mountpoint"], try(local.configuration_yml["homedir_mountpoint"], "/anfhome"))
 
     admin_username = local.configuration_yml["admin_user"]
     key_vault_readers = try(local.configuration_yml["key_vault_readers"], null)


### PR DESCRIPTION
- make optional the creation of the ANF account, pool and volume used to host the users home directory
- added a new section for the ANF settings while maintaining the old syntax
- added a new section for listing the mountpoints, especially for the home while maintaining the old syntax

close #474 
close #152 