### PR TITLE
typo in rbh_sku name

### DIFF
--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -32,7 +32,7 @@ locals {
 
     # Lustre
     lustre_archive_account = try(local.configuration_yml["lustre"]["hsm"]["storage_account"], null)
-    lustre_rbh_sku = try(local.configuration_yml["lustre"]["rhb_sku"], "Standard_D8d_v4")
+    lustre_rbh_sku = try(local.configuration_yml["lustre"]["rbh_sku"], "Standard_D8d_v4")
     lustre_mds_sku = try(local.configuration_yml["lustre"]["mds_sku"], "Standard_D8d_v4")
     lustre_oss_sku = try(local.configuration_yml["lustre"]["oss_sku"], "Standard_D32d_v4")
     lustre_oss_count = try(local.configuration_yml["lustre"]["oss_count"], 2)


### PR DESCRIPTION
variable name used to read the robinhood sku has a type meaning that the robinhood VM size was always set to Standard_D8d_v4