### PR TITLE
create user accounts in cyclecloud

### DIFF
--- a/playbooks/add_users.yml
+++ b/playbooks/add_users.yml
@@ -17,7 +17,7 @@
 
   tasks:
   - include: create_user.yml user="{{item}}"
-    with_items: users
+    with_items: '{{users}}'
     when: users is defined
 
 - name: close socks tunnel
@@ -37,5 +37,17 @@
 
   tasks:
   - include: init_user.yml user="{{item}}"
-    with_items: users
+    with_items: '{{users}}'
     when: users is defined
+
+- name: Configure users in CycleCloud
+  hosts: ccportal
+  become: true
+  vars_files:
+    - '{{global_config_file}}'
+
+  tasks:
+  - name: Add users
+    template:
+      src: user_record.txt.j2
+      dest: /opt/cycle_server/config/data/user_record.txt

--- a/playbooks/create_user.yml
+++ b/playbooks/create_user.yml
@@ -1,3 +1,8 @@
+- name: debug
+  debug:
+    msg:
+      - "user={{user}}"
+  
 - name: Read Password from KV
   command: az keyvault secret show --vault-name {{key_vault}} -n {{user.name}}-password --query "value" -o tsv
   delegate_to: localhost

--- a/playbooks/roles/cyclecloud/files/user_role_record.txt
+++ b/playbooks/roles/cyclecloud/files/user_role_record.txt
@@ -4,3 +4,9 @@ OwnerAllow = {"Clusters/Administer","Data/Manage","Clusters/Manage","Clusters/Co
 GroupRole = false
 Name = "User"
 Allow = {"Package.Release/View","System/AccessWebSite","Alerts/Manage","Clusters/View","Clusters/Access"}
+
+AdType = "Application.Role"
+Description = "AZHOP Cluster Admin"
+GroupRole = false
+Name = "azhop Cluster Admin"
+Allow = {"Clusters/Manage"}

--- a/playbooks/templates/user_record.txt.j2
+++ b/playbooks/templates/user_record.txt.j2
@@ -1,0 +1,13 @@
+{% for user in users %}
+AdType = "AuthenticatedUser"
+Name =  "{{ user.name }}"
+Authentication = "active_directory"
+{% if (user.admin is defined) and user.admin %}
+Roles = {"azhop Cluster Admin"}
+{% else %}
+Roles = {"User"}
+{% endif %}
+UID = {{ user.uid }}
+Superuser = false
+
+{% endfor %}


### PR DESCRIPTION
- add a new role for azhop cluster admin
- non admin users are added with the User role
- admin users are added with the azhop cluster admin role

