### PR TITLE
change file upload staging to /mnt/resource

### DIFF
--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -284,5 +284,11 @@
       regexp: 'limit: 1,$'
       replace: 'limit: 1, timeout: 0,'
 
+  - name: create cron entry to make sure the passenger-tmp folder exists
+    cron:
+      name: "create passenger tmp directory and set permissions"
+      minute: "0,10,20,30,40,50"
+      job: "test -e /mnt/resource/passenger-tmp || (mkdir /mnt/resource/passenger-tmp && chmod 777 /mnt/resource/passenger-tmp)"
+
   - name: restart ood
     shell: systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service


### PR DESCRIPTION
- change passenger-tmp folder to /mnt/resource
- change pun_tmp_root to /mnt/resource
- disable Uppy timeout
- add a cron which run every 10mn to recreate the passenger-tmp folder in case of node restart

close #534 Change the upload folder to the ondemand ephemeral disk
close #532 cannot upload files larger than few MB 
