### PR TITLE
remove _ in queue names for SLURM compatibility

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -199,12 +199,12 @@ queues:
     max_core_count: 440
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest
 #    image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-v2-rdma-gpgpu/latest
-  - name: hb120rs_v2
+  - name: hb120v2
     vm_size: Standard_HB120rs_v2
     max_core_count: 1200
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest
 #    image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-v2-rdma-gpgpu/latest
-  - name: hb120rs_v3
+  - name: hb120v3
     vm_size: Standard_HB120rs_v3
     max_core_count: 1200
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest

--- a/docs/deploy/build_images.md
+++ b/docs/deploy/build_images.md
@@ -60,7 +60,7 @@ To specify the new custom images to use, just comment the default `image: OpenLo
 *Before the update*
 ```yml
 queues:
-  - name: hb120rs_v3
+  - name: hb120v3
     vm_size: Standard_HB120rs_v3
     max_core_count: 1200
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest
@@ -77,7 +77,7 @@ queues:
 *After the update*
 ```yml
 queues:
-  - name: hb120rs_v3
+  - name: hb120v3
     vm_size: Standard_HB120rs_v3
     max_core_count: 1200
 #    image: OpenLogic:CentOS-HPC:7_9-gen2:latest

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -204,12 +204,12 @@ queues:
     max_core_count: 440
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest
 #    image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-v2-rdma-gpgpu/latest
-  - name: hb120rs_v2
+  - name: hb120v2
     vm_size: Standard_HB120rs_v2
     max_core_count: 1200
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest
 #    image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-v2-rdma-gpgpu/latest
-  - name: hb120rs_v3
+  - name: hb120v3
     vm_size: Standard_HB120rs_v3
     max_core_count: 1200
     image: OpenLogic:CentOS-HPC:7_9-gen2:latest

--- a/docs/tutorials/openfoam.md
+++ b/docs/tutorials/openfoam.md
@@ -13,7 +13,7 @@ sed '/^  build_stage:$/a \ \ \ \ - /mnt/resource/$user/spack-stage' $HOME/spack/
 ## Start an interactive job on a compute node
 
 ```bash
-qsub -l select=1:slot_type=hb120rs_v2 -I
+qsub -l select=1:slot_type=hb120v2 -I
 ```
 
 > Note: alternatively you could create a code-server session instead from the ondemand dashboard.
@@ -119,7 +119,7 @@ Submit the script:
 ```
 nodes=8
 ppn=120
-qsub -l select=${nodes}:slot_type=hb120rs_v2:ncpus=120:mpiprocs=${ppn},place=scatter:excl submit.sh
+qsub -l select=${nodes}:slot_type=hb120v2:ncpus=120:mpiprocs=${ppn},place=scatter:excl submit.sh
 ```
 
 ## Visualizing

--- a/playbooks/files/ood_templates/openpbs/impi_pingpong/manifest.yml
+++ b/playbooks/files/ood_templates/openpbs/impi_pingpong/manifest.yml
@@ -1,5 +1,5 @@
 ---
 name: Intel MPI PingPong
 host: ondemand
-notes: A very basic template for running Intel MPI ping pong. Default is to run on hb120rs_v3, make sure to edit the script if you want to run on another node type
+notes: A very basic template for running Intel MPI ping pong. Default is to run on hb120v3, make sure to edit the script if you want to run on another node type
 script: pingpong.sh

--- a/playbooks/files/ood_templates/openpbs/impi_pingpong/pingpong.sh
+++ b/playbooks/files/ood_templates/openpbs/impi_pingpong/pingpong.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N PingPong
-#PBS -l select=2:ncpus=1:mpiprocs=1:slot_type=hb120rs_v3
+#PBS -l select=2:ncpus=1:mpiprocs=1:slot_type=hb120v3
 #PBS -k oed
 #PBS -j oe
 #PBS -l walltime=300

--- a/playbooks/files/ood_templates/openpbs/impi_ring_pingpong/manifest.yml
+++ b/playbooks/files/ood_templates/openpbs/impi_ring_pingpong/manifest.yml
@@ -1,5 +1,5 @@
 ---
 name: Intel MPI Ring PingPong
 host: ondemand
-notes: A very basic template for running Intel MPI ping pong in a ring. Default is to run on 4xhb120rs_v3, make sure to edit the script if you want to run on more nodes or another node type
+notes: A very basic template for running Intel MPI ping pong in a ring. Default is to run on 4xhb120v3, make sure to edit the script if you want to run on more nodes or another node type
 script: ring_pingpong.sh

--- a/playbooks/files/ood_templates/openpbs/impi_ring_pingpong/ring_pingpong.sh
+++ b/playbooks/files/ood_templates/openpbs/impi_ring_pingpong/ring_pingpong.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N RingPingPong
-#PBS -l select=4:ncpus=1:mpiprocs=1:slot_type=hb120rs_v3
+#PBS -l select=4:ncpus=1:mpiprocs=1:slot_type=hb120v3
 #PBS -k oed
 #PBS -j oe
 #PBS -l walltime=300


### PR DESCRIPTION
close #661 

>Note : Renaming the default queue names can introduce breaking changes in scripts using these in `slot_type`