### PR TITLE
Fix OpenPBS jobs not starting because nodes were not registered in PBS

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
@@ -23,7 +23,7 @@ Autoscale = true
         keepalive.timeout = 3600 # The amount of time in seconds to keep a node "alive" if it has not finished installing/configuring software.
         cyclecloud.converge_on_boot = true
         # False => This is to avoid hostnames to be renamed ip-XXXXXXXX
-        cyclecloud.hosts.standalone_dns.enabled = true
+        cyclecloud.hosts.standalone_dns.enabled = false
         #cyclecloud.dns.domain = {{ad_join_domain}}
 
         # Disable normal NFS exports and mounts


### PR DESCRIPTION
Issue was related to hostnames being bad renamed and were not resolvable by the scheduler. Had to changed `standalone_dns.enabled` from `true` to `false` in the cluster cycle template.

close #676 

This will provide a fix node naming convention with increment namings.