### PR TITLE
Increase slurm.dampen_memory to 8

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -77,7 +77,7 @@ Autoscale = true
         slurm.autoscale = true
         #slurm.node_prefix = ${ifThenElse(NodeNamePrefix=="Cluster Prefix", StrJoin("-", ClusterName, ""), NodeNamePrefix)}
         slurm.use_nodename_as_hostname = true
-
+        slurm.dampen_memory = 8 # Reservation of 8% of the node's memory
         [[[cluster-init cyclecloud/slurm:execute:{{cyclecloud_slurm_release}}]]]
 
 {% for queue in cc_queues %}

--- a/playbooks/roles/tests/files/slurm_helpers.sh
+++ b/playbooks/roles/tests/files/slurm_helpers.sh
@@ -27,6 +27,7 @@ function wait_alljobs()
     if [ $wait_time -ge $MAX_WAIT_TIME ]; then
         echo "Timeout while waiting for jobs"
         sinfo -l
+        sinfo -R
         squeue -l
         scancel -n $jobgroup
         exit 1


### PR DESCRIPTION
Incease the value of slurm.dampen_memory to 8 from 5 to solve issues with nodes with a low memory presence.

close #686 