### PR TITLE
Allow access to node activities and metrics. Deny access to settings

### DIFF
--- a/playbooks/roles/cyclecloud/files/user_role_record.txt
+++ b/playbooks/roles/cyclecloud/files/user_role_record.txt
@@ -1,12 +1,17 @@
+AdType="Application.Permission"
+Name="Fixed.ClusterMetadata"
+ForTypes = {"Cloud.Instance","Cloud.InstanceSession","Cloud.Locker","Cloud.MachineType","Cloud.Price","Cloud.ProviderAccount","Cloud.Region","ClusterMetrics","NodeMetrics","Activity"}
+Operations="Read"
+Hidden=true
+
 AdType = "Application.Role"
 Description = "Basic GUI access"
-OwnerAllow = {"Package.Release/View","System/AccessWebSite","Alerts/Manage","Clusters/View","Clusters/Access"}
 GroupRole = false
 Name = "User"
-Allow = {"Package.Release/View","System/AccessWebSite","Alerts/Manage","Clusters/View","Clusters/Access"}
+Allow = {"Package.Release/View","System/AccessWebSite","Alerts/Manage","Clusters/View","Clusters/Access", "Fixed.ClusterMetadata"}
 
 AdType = "Application.Role"
 Description = "AZHOP Cluster Admin"
 GroupRole = false
 Name = "azhop Cluster Admin"
-Allow = {"Clusters/Manage"}
+Allow = {"Clusters/Manage", "Fixed.ClusterMetadata"}


### PR DESCRIPTION
New permission which will allows access to read node activities, node metrics, core hours and cost. It will deny access to the configuration settings.
close #688
close #690