### PR TITLE
create az-hop-admins group

### DIFF
--- a/playbooks/ad.yml
+++ b/playbooks/ad.yml
@@ -82,7 +82,14 @@
           state: present
         with_items: '{{dns.forwarders}}'
         when: dns.forwarders is defined
-  
+
+      - name: Add az-hop admin group
+        community.windows.win_domain_group:
+          name: az-hop-admins
+          state: present
+          description: Members of this group can perform administrative tasks on the az-hop environment
+          scope: domainlocal
+
     always:
       - name: close session on local port
         shell: ps aux | grep localhost:5985 | grep -v grep | awk '{print "kill -9 " $2}' | sh

--- a/playbooks/create_user.yml
+++ b/playbooks/create_user.yml
@@ -38,6 +38,7 @@
     password: '{{password.stdout}}'
     password_never_expires: true
     state: present
+    groups_action: replace
     groups:
       - Domain Users
     attributes:
@@ -47,19 +48,12 @@
       unixhomedirectory: "{{ user_home }}"
       gidnumber: "{{user.gid}}"
 
+# Add admin users into the az-hop-admins group
 - name: add Admin
   community.windows.win_domain_user:
     name: "{{ user.name }}"
-    firstname: "{{ user.name }}"
-    password: '{{password.stdout}}'
-    password_never_expires: true
     state: present
     groups:
-      - Domain Admins
-    attributes:
-      uidNumber: "{{ user.uid }}"
-      uid: "{{ user.name }}"
-      loginShell: "{{ user_shell }}"
-      unixhomedirectory: "{{ user_home }}"
-      gidnumber: "{{user.gid}}"
+      - az-hop-admins
+
   when: user.admin | default(false)

--- a/playbooks/roles/grafana/templates/ldap.toml.j2
+++ b/playbooks/roles/grafana/templates/ldap.toml.j2
@@ -47,7 +47,7 @@ email =  "email"
 
 # Map ldap groups to grafana org roles
 [[servers.group_mappings]]
-group_dn = "cn=Domain Admins,cn=Users,dc=hpc,dc=azure"
+group_dn = "cn=az-hop-admins,cn=Users,dc=hpc,dc=azure"
 org_role = "Admin"
 # To make user an instance admin  (Grafana Admin) uncomment line below
 # grafana_admin = true


### PR DESCRIPTION
- create an az-hop-admins group for admin users
- azhop users are only part of the Domain Users group
- Grafana map the az-hop-admins group to role admin
close #740