### PR TITLE
Multiple vnet peering support

### DIFF
--- a/.github/workflows/configs/integration.yml
+++ b/.github/workflows/configs/integration.yml
@@ -63,9 +63,9 @@ network:
         name: compute
         address_prefixes: "10.0.16.0/20"
         create: true
-  peering: # This is optional, and can be used to create a VNet Peering in the same subscription.
-    vnet_name: #"VNET Name to Peer to"
-    vnet_resource_group: #"Resource Group of the VNET to peer to"
+  peering: # This list is optional, and can be used to create VNet Peerings in the same subscription.
+    #- vnet_name: #"VNET Name to Peer to"
+    #  vnet_resource_group: #"Resource Group of the VNET to peer to"
 # When working in a locked down network, uncomment and fill out this section
 locked_down_network:
   enforce: false

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -59,8 +59,8 @@ locals {
     vnet_id = try(local.configuration_yml["network"]["vnet"]["id"], null)
 
     # VNET Peering
-    vnet_peering = try(length(local.configuration_yml["network"]["peering"]), 0) > 0 ? local.configuration_yml["network"]["peering"] : []
-    
+    vnet_peering = try(tolist(configuration_yml["network"]["peering"]), [])
+
     # Lockdown scenario
     locked_down_network = try(local.configuration_yml["locked_down_network"]["enforce"], false)
     grant_access_from   = try(local.configuration_yml["locked_down_network"]["grant_access_from"], [])

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -59,7 +59,7 @@ locals {
     vnet_id = try(local.configuration_yml["network"]["vnet"]["id"], null)
 
     # VNET Peering
-    vnet_peering = try(tolist(configuration_yml["network"]["peering"]), [])
+    vnet_peering = try(tolist(local.configuration_yml["network"]["peering"]), [])
 
     # Lockdown scenario
     locked_down_network = try(local.configuration_yml["locked_down_network"]["enforce"], false)

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -59,8 +59,8 @@ locals {
     vnet_id = try(local.configuration_yml["network"]["vnet"]["id"], null)
 
     # VNET Peering
-    vnet_peering = try(length(local.configuration_yml["network"]["peering"]) > 0 ? local.configuration_yml["network"]["peering"] : [])
-
+    vnet_peering = try(length(local.configuration_yml["network"]["peering"]), 0) > 0 ? local.configuration_yml["network"]["peering"] : []
+    
     # Lockdown scenario
     locked_down_network = try(local.configuration_yml["locked_down_network"]["enforce"], false)
     grant_access_from   = try(local.configuration_yml["locked_down_network"]["grant_access_from"], [])


### PR DESCRIPTION
Fixed issue with previous commit.  The old format for peering will not break the build although the peering will not be created.