### PR TITLE
Force playbook execution when a playbook is specified

### DIFF
--- a/docs/deploy/configure_toolchain.md
+++ b/docs/deploy/configure_toolchain.md
@@ -15,6 +15,7 @@ git clone --recursive https://github.com/Azure/az-hop.git -b <version>
 - Option 2
 ```bash
 git clone https://github.com/Azure/az-hop.git -b <version>
+cd az-hop
 git submodule init
 git submodule update
 ```
@@ -53,10 +54,10 @@ Run the `install.sh` from the _toolset/scripts_ directory in Ubuntu 20.04.
 ```
 
 ## From a deployer VM
-`az-hop` can be deployed directly from an Azure VM used preferably behind a Bastion, in that case do the following :
+`az-hop` can be deployed directly from an Ubuntu Azure VM used preferably behind a Bastion, in that case do the following :
 - Create a Bastion
-- Create a `deployer` VM without a public IP
-- Connect to the `deployer` VM from the Bastion
+- Create a `deployer` VM running Ubuntu without a public IP
+- Connect to the `deployer` VM from Bastion
 - Clone the repo as explained above
 - Install the toolset by running `sudo ./az-hop/toolset/scripts/install.sh`
 

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -1,17 +1,16 @@
-# How To
+# How To <!-- omit in toc -->
 
-- [How To](#how-to)
-  - [How to use an existing VNET ?](#how-to-use-an-existing-vnet-)
-    - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
-    - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
-  - [How to deploy ANF with Dual protocol](#how-to-deploy-anf-with-dual-protocol)
-  - [Deploy in a locked down network environment](#deploy-in-a-locked-down-network-environment)
-  - [Disable Public IP scenario](#disable-public-ip-scenario)
-  - [Use your own SSL certificate](#use-your-own-ssl-certificate)
-  - [Not deploy ANF](#not-deploy-anf)
-  - [Use an existing NFS mount point](#use-an-existing-nfs-mount-point)
-  - [Use Azure Active Directory for MFA](#use-azure-active-directory-for-mfa)
-  - [Add/remove/modify cluster node arrays (aka queues/partitions)](#addremovemodify-cluster-node-arrays-aka-queuespartitions)
+- [How to use an existing VNET ?](#how-to-use-an-existing-vnet-)
+  - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
+  - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
+- [How to deploy ANF with Dual protocol](#how-to-deploy-anf-with-dual-protocol)
+- [Deploy in a locked down network environment](#deploy-in-a-locked-down-network-environment)
+- [Disable Public IP scenario](#disable-public-ip-scenario)
+- [Use your own SSL certificate](#use-your-own-ssl-certificate)
+- [Not deploy ANF](#not-deploy-anf)
+- [Use an existing NFS mount point](#use-an-existing-nfs-mount-point)
+- [Use Azure Active Directory for MFA](#use-azure-active-directory-for-mfa)
+- [Add/remove/modify cluster node arrays (aka queues/partitions)](#addremovemodify-cluster-node-arrays-aka-queuespartitions)
 
 ## How to use an existing VNET ?
 Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.

--- a/docs/deploy/how_to.md
+++ b/docs/deploy/how_to.md
@@ -1,15 +1,17 @@
 # How To
 
-- [How to use an existing VNET ?](#how-to-use-an-existing-vnet)
-  - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
-  - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
-- [How to deploy ANF with Dual protocol ?](#how-to-deploy-anf-with-dual-protocol)
-- [How to deploy in a locked down network environment ?](#deploy-in-a-locked-down-network-environment)
-- [Disable Public IP scenario](#disable-public-ip-scenario)
-- [Use your own SSL certificate](#use-your-own-ssl-certificate)
-- [Not deploy ANF](#not-deploy-anf)
-- [Use an existing NFS mount point](#use-an-existing-nfs-mount-point)
-- [Use Azure Active Directory for MFA](#use-azure-active-directory-for-mfa)
+- [How To](#how-to)
+  - [How to use an existing VNET ?](#how-to-use-an-existing-vnet-)
+    - [Pre-requisities for using an existing VNET](#pre-requisities-for-using-an-existing-vnet)
+    - [Creating a standalone VNET for AZ-HOP](#creating-a-standalone-vnet-for-az-hop)
+  - [How to deploy ANF with Dual protocol](#how-to-deploy-anf-with-dual-protocol)
+  - [Deploy in a locked down network environment](#deploy-in-a-locked-down-network-environment)
+  - [Disable Public IP scenario](#disable-public-ip-scenario)
+  - [Use your own SSL certificate](#use-your-own-ssl-certificate)
+  - [Not deploy ANF](#not-deploy-anf)
+  - [Use an existing NFS mount point](#use-an-existing-nfs-mount-point)
+  - [Use Azure Active Directory for MFA](#use-azure-active-directory-for-mfa)
+  - [Add/remove/modify cluster node arrays (aka queues/partitions)](#addremovemodify-cluster-node-arrays-aka-queuespartitions)
 
 ## How to use an existing VNET ?
 Using an existing VNET can be done by specifying in the `config.yml` file the VNET ID that needs to be used as shown below.
@@ -184,3 +186,12 @@ The helper script `configure_aad.sh` can be used to
 - Create a secret for this AAD application and store it in the az-hop Key Vault
 
 This script need to be run before the `install.sh` or at least before the `ood` step.
+
+## Add/remove/modify cluster node arrays (aka queues/partitions)
+Az-HOP simplifies the addition, removal or modification of the node arrays in an existing CycleCloud cluster.
+Simply edit the `config.yml` file with the desired changes in the `queues` section. Then update the `cccluster` and `scheduler` installation with:
+```bash
+./install cccluster
+./install scheduler
+```
+The node arrays changes will appear in the CycleCloud portal and as cluster scheduler partitions.

--- a/docs/deploy/install.md
+++ b/docs/deploy/install.md
@@ -19,11 +19,12 @@ The simpler is just to run
 ```bash
 ./install.sh
 ```
-and let it go
+and let it go. The script will automatically skip playbooks that have been previously executed and completed successfully.
 
 If you need to apply only a subset then run 
 ```bash
 ./install.sh <target> # with a single target in the list above
 ```
+When requesting the execution of a specific playbook, the script will force execution even if the playbook successfully completed on a previous run.
 
 In case of a transient failure, the install script can be reapplied as most of the settings are idempotent. The script contains a checkpointing mechanism, each sucessfully applied target will have a `.ok` file created in the playbooks directory. If you want to re-apply a target, delete this file and rerun the install script.

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,9 @@ function run_playbook ()
   shift
   local extra_vars_file=$@
 
-  # If playbook marker doesn't exists, run it
-  if [ ! -e $PLAYBOOKS_DIR/$playbook.ok ]; then
+  # If running all playbooks and playbook marker doesn't exists, run the playbook
+  # If user requested specific playbook ignore marker file and force run
+  if [ ! -e $PLAYBOOKS_DIR/$playbook.ok ] || [ "$TARGET" != "all" ]; then
     local options=""
     if [ "$extra_vars_file" != "" ]; then
       # Merge overrides variables in a single file


### PR DESCRIPTION
Changes:

- When a specific playbook name is passed as command line argument to `install.sh` the playbook is executed even if a corresponding `.ok` file is already present.
- Updated install step documentation to highlight the above behavior
- Added deployment how-to for adding/modifying cluster queue/partition