### PR TITLE
Install CycleCloud from RPMs

### DIFF
--- a/.github/workflows/configs/integration.yml
+++ b/.github/workflows/configs/integration.yml
@@ -86,15 +86,6 @@ scheduler:
   vm_size: Standard_B2ms
 cyclecloud:
   vm_size: Standard_B2ms
-  image:
-    publisher: "azurecyclecloud"
-    offer:     "azure-cyclecloud"
-    sku:       "cyclecloud8"
-    version:   "8.2.120211111"
-  plan:
-    name: "cyclecloud8"
-    publisher:  "azurecyclecloud"
-    product:    "azure-cyclecloud"
 
 winviz:
   vm_size: Standard_D4_v5

--- a/.github/workflows/main_callable.yml
+++ b/.github/workflows/main_callable.yml
@@ -259,6 +259,7 @@ jobs:
         run: |
           RESOURCE_GROUP=${{needs.deploy.outputs.resource_group}}
           ./azhop_state.sh download ${{ env.AZHOP_STATE_ACCOUNT }} ${{ env.AZHOP_STATE_CONTAINER }} $RESOURCE_GROUP
+          export ANSIBLE_VERBOSITY=4
           ./install.sh ccportal
           ./install.sh add_users
           ./install.sh cccluster

--- a/.github/workflows/main_callable.yml
+++ b/.github/workflows/main_callable.yml
@@ -259,11 +259,8 @@ jobs:
         run: |
           RESOURCE_GROUP=${{needs.deploy.outputs.resource_group}}
           ./azhop_state.sh download ${{ env.AZHOP_STATE_ACCOUNT }} ${{ env.AZHOP_STATE_CONTAINER }} $RESOURCE_GROUP
-          export ANSIBLE_VERBOSITY=4
           ./install.sh ccportal
           ./install.sh add_users
-          ./install.sh cccluster
-          ./install.sh scheduler
 
   add_users:
     name: add_users

--- a/.github/workflows/main_callable.yml
+++ b/.github/workflows/main_callable.yml
@@ -160,7 +160,6 @@ jobs:
           ./azhop_state.sh download ${{ env.AZHOP_STATE_ACCOUNT }} ${{ env.AZHOP_STATE_CONTAINER }} $RESOURCE_GROUP
           ./install.sh ad
           ./install.sh linux
-          ./install.sh add_users
 
   lustre:
     name: lustre
@@ -261,6 +260,7 @@ jobs:
           RESOURCE_GROUP=${{needs.deploy.outputs.resource_group}}
           ./azhop_state.sh download ${{ env.AZHOP_STATE_ACCOUNT }} ${{ env.AZHOP_STATE_CONTAINER }} $RESOURCE_GROUP
           ./install.sh ccportal
+          ./install.sh add_users
           ./install.sh cccluster
           ./install.sh scheduler
 

--- a/build.sh
+++ b/build.sh
@@ -81,17 +81,17 @@ terraform -chdir=$TF_FOLDER init -upgrade
 yamllint $AZHOP_CONFIG
 
 # Accept Cycle marketplace image terms
-cc_plan=$(yq eval '.cyclecloud.plan.name' $AZHOP_CONFIG)
-if [ "$cc_plan" == "" ]; then
-  cc_plan="cyclecloud8"
-fi
-accepted=$(az vm image terms show --offer azure-cyclecloud --publisher azurecyclecloud --plan $cc_plan --query 'accepted' -o tsv)
-if [ "$accepted" != "true" ]; then
-  echo "Azure CycleCloud marketplace image terms are not accepted, accepting them now"
-  az vm image terms accept --offer azure-cyclecloud --publisher azurecyclecloud --plan $cc_plan -o tsv
-else
-  echo "Azure CycleCloud marketplace image terms already accepted"
-fi
+# cc_plan=$(yq eval '.cyclecloud.plan.name' $AZHOP_CONFIG)
+# if [ "$cc_plan" == "" ]; then
+#   cc_plan="cyclecloud8"
+# fi
+# accepted=$(az vm image terms show --offer azure-cyclecloud --publisher azurecyclecloud --plan $cc_plan --query 'accepted' -o tsv)
+# if [ "$accepted" != "true" ]; then
+#   echo "Azure CycleCloud marketplace image terms are not accepted, accepting them now"
+#   az vm image terms accept --offer azure-cyclecloud --publisher azurecyclecloud --plan $cc_plan -o tsv
+# else
+#   echo "Azure CycleCloud marketplace image terms already accepted"
+# fi
 
 # Accept Lustre marketplace image terms
 accepted=$(az vm image terms show --offer azurehpc-lustre --publisher azhpc --plan azurehpc-lustre-2_12 --query 'accepted' -o tsv)

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -106,13 +106,7 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-# uncomment if updated RPMS need to be applied
-#  rpms:
-    # optional URL to apply a fix on the marketplace image deployed on the ccportal
-#    cyclecloud:
-    # mandatory URL on the jetpack RPM to be installed on the ccportal and the scheduler
-#    jetpack:
-
+  # version: 8.2.1-1733 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
 winviz:
   vm_size: Standard_D4s_v3
   create: false # Create an always running windows node, false by default

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -106,17 +106,6 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-  # Azure Image Reference for CycleCloud. Default to 8.2.120211111 if not present
-  image: 
-    publisher: "azurecyclecloud"
-    offer:     "azure-cyclecloud"
-    sku:       "cyclecloud8"
-    version:   "8.2.120211111"
-  # Azure Image Plan for CycleCloud. Default to 8 if not present
-  plan: 
-    name:      "cyclecloud8"
-    publisher: "azurecyclecloud"
-    product:   "azure-cyclecloud"
 # uncomment if updated RPMS need to be applied
 #  rpms:
     # optional URL to apply a fix on the marketplace image deployed on the ccportal

--- a/docs/deploy/azure_prereqs.md
+++ b/docs/deploy/azure_prereqs.md
@@ -11,10 +11,6 @@
   - **Reader** on the subscription
 - Your subscription need to be registered for NetApp resource provider as explained [here](https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-register#waitlist)
 - If using ANF Dual Protocol be aware of the limitation of one ANF account allow to be domain joined per region in the same subscription
-- The CycleCloud marketplace image need to be allowed, this is the default unless your subscription have a policy blocking it. The EULA terms need to be accepted, this is done in the build script, but if you are not granted to do so, ask your administrator to run this command :
-```bash
-az vm image terms accept --offer azure-cyclecloud --publisher azurecyclecloud --plan cyclecloud8
-```
 - The Azure HPC Lustre marketplace image terms need to be accepted
 ```bash
 az vm image terms accept --offer azurehpc-lustre --publisher azhpc --plan azurehpc-lustre-2_12

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -111,17 +111,6 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-  # Azure Image Reference for CycleCloud. Default to 8.2.120211111 if not present
-  image: 
-    publisher: "azurecyclecloud"
-    offer:     "azure-cyclecloud"
-    sku:       "cyclecloud8"
-    version:   "8.2.120211111"
-  # Azure Image Plan for CycleCloud. Default to 8 if not present
-  plan: 
-    name:      "cyclecloud8"
-    publisher: "azurecyclecloud"
-    product:   "azure-cyclecloud"
 # uncomment if updated RPMS need to be applied
 #  rpms:
     # optional URL to apply a fix on the marketplace image deployed on the ccportal

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -111,12 +111,7 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-# uncomment if updated RPMS need to be applied
-#  rpms:
-    # optional URL to apply a fix on the marketplace image deployed on the ccportal
-#    cyclecloud:
-    # mandatory URL on the jetpack RPM to be installed on the ccportal and the scheduler
-#    jetpack:
+  # version: 8.2.1-1733 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
 
 winviz:
   vm_size: Standard_D4s_v3

--- a/install.sh
+++ b/install.sh
@@ -67,10 +67,10 @@ case $TARGET in
   all)
     run_playbook ad
     run_playbook linux
-    run_playbook add_users
     run_playbook lustre-sas
     run_playbook lustre
     run_playbook ccportal
+    run_playbook add_users
     run_playbook cccluster
     run_playbook scheduler
     run_playbook ood $PLAYBOOKS_DIR/ood-overrides-common.yml $PLAYBOOKS_DIR/ood-overrides-$SCHEDULER.yml $PLAYBOOKS_DIR/ood-overrides-auth-$OOD_AUTH.yml

--- a/playbooks/cccluster.yml
+++ b/playbooks/cccluster.yml
@@ -10,7 +10,7 @@
   become: true
   gather_facts: no
   vars:
-    - ansible_python_interpreter: /usr/bin/python3
+#    - ansible_python_interpreter: /usr/bin/python3
     - lookup_img_file: image_lookup.yml
   vars_files:
     - '{{global_config_file}}'

--- a/playbooks/cccluster.yml
+++ b/playbooks/cccluster.yml
@@ -9,7 +9,6 @@
   become: true
   gather_facts: no
   vars:
-#    - ansible_python_interpreter: /usr/bin/python3
     - lookup_img_file: image_lookup.yml
   vars_files:
     - '{{global_config_file}}'

--- a/playbooks/cccluster.yml
+++ b/playbooks/cccluster.yml
@@ -1,10 +1,9 @@
 ---
 # This looks crazy but in order for this playbook to run from a pipeline, the jumpbox dummy need to be added
-# - name: jumpbox dummy
-#   hosts: jumpbox
-#   become: true
-#   vars_files:
-#     - '{{global_config_file}}'
+- name: jumpbox dummy
+  hosts: jumpbox
+  become: true
+
 - name: Setup cyclecloud
   hosts: ccportal
   become: true

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -1,8 +1,8 @@
 ---
 # This looks crazy but in order for this playbook to run from a pipeline, the jumpbox dummy need to be added
-# - name: jumpbox dummy
-#   hosts: jumpbox
-#   become: true
+- name: jumpbox dummy
+  hosts: jumpbox
+  become: true
 
 - name: Setup Cycle Cloud
   hosts: ccportal

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -8,8 +8,6 @@
   hosts: ccportal
   become: true
   gather_facts: no
-  # vars:
-  #   - ansible_python_interpreter: /usr/bin/python3
   vars_files:
     - '{{global_config_file}}'
 
@@ -38,5 +36,4 @@
       cc_storage: '{{global_cc_storage}}'
       cc_domain: '{{ad_join_domain}}'
       cc_ad_server: '{{ldap_server}}'
-      cc_rpms_jetpack: '{{ cyclecloud.rpms.jetpack | default(None) }}'
-      cc_rpms_cycle: '{{ cyclecloud.rpms.cyclecloud | default(None) }}'
+      cc_version: '{{cyclecloud.version | default("8.2.1-1733")}}'

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -8,8 +8,8 @@
   hosts: ccportal
   become: true
   gather_facts: no
-  vars:
-    - ansible_python_interpreter: /usr/bin/python3
+  # vars:
+  #   - ansible_python_interpreter: /usr/bin/python3
   vars_files:
     - '{{global_config_file}}'
 

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -1,8 +1,8 @@
 ---
 # This looks crazy but in order for this playbook to run from a pipeline, the jumpbox dummy need to be added
-- name: jumpbox dummy
-  hosts: jumpbox
-  become: true
+# - name: jumpbox dummy
+#   hosts: jumpbox
+#   become: true
 
 - name: Setup Cycle Cloud
   hosts: ccportal

--- a/playbooks/roles/cyclecloud/defaults/all.yml
+++ b/playbooks/roles/cyclecloud/defaults/all.yml
@@ -4,6 +4,4 @@ cc_password:
 cc_storage:
 cc_domain:
 cc_ad_server:
-cc_rpms_jetpack:
-cc_rpms_cycle:
-
+cc_version:

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -8,6 +8,104 @@
   reboot:
   when: selinux.reboot_required 
 
+# setup CycleCloud. Ported from https://github.com/Azure/cyclecloud-marketplace-image/blob/main/scripts/setup_cyclecloud.sh
+
+- name: Update packages marked for security
+  yum:
+    state: latest
+    security: yes
+
+
+- name: install AZ CLI repo
+  shell: |
+    set -e
+    rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    cat > /etc/yum.repos.d/azure-cli.repo <<EOF
+    [azure-cli]
+    name=Azure CLI
+    baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+    EOF
+  args:
+    creates: /etc/yum.repos.d/azure-cli.repo
+
+- name: install CycleCloud repo
+  shell: |
+    cat > /etc/yum.repos.d/cyclecloud.repo <<EOF
+    [cyclecloud]
+    name=cyclecloud
+    baseurl=https://packages.microsoft.com/yumrepos/cyclecloud
+    gpgcheck=1
+    gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+    EOF
+  args:
+    creates: /etc/yum.repos.d/cyclecloud.repo
+
+- name: mount data disk
+  shell: |
+    set -e
+    parted /dev/disk/azure/scsi1/lun0 --script -- mklabel gpt
+    parted -a optimal /dev/disk/azure/scsi1/lun0 mkpart primary 0% 100%
+    # try a sleep here to wait for the symlink
+    sleep 10s
+    mkfs -t xfs /dev/disk/azure/scsi1/lun0-part1
+    disk_uuid=$(blkid -o value -s UUID  /dev/disk/azure/scsi1/lun0-part1)
+    mkdir /opt/cycle_server
+    echo "UUID=$disk_uuid /opt/cycle_server xfs defaults,nofail 1 2" >> /etc/fstab
+    mount -a
+    touch /tmp/data_disk_mounted
+  args:
+    creates: /tmp/data_disk_mounted
+
+
+- name: Install cyclecloud packages
+  yum:
+    name:
+      - azure-cli
+      - cyclecloud
+      - dnsmasq
+    state: present
+
+- name: Create a data record for azhop and start cycleserver
+  shell: |
+    set -e
+    # create a data record to identify this installation as an az-hop VM
+    cat > /opt/cycle_server/config/data/azhop.txt <<EOF
+    AdType = "Application.Setting"
+    Name = "site_id"
+    Value = "azhop"
+    EOF
+    /opt/cycle_server/cycle_server await_startup
+    /opt/cycle_server/cycle_server execute 'update Application.Setting set Value = undefined where Name == "site_id" || Name == "reported_version"'
+  args:
+    creates: /opt/cycle_server/config/data/azhop.txt.ok
+
+- name: Extract and install the CLI
+  shell: |
+    set -e
+    _tmpdir=$(mktemp -d)
+    pushd $_tmpdir
+    CS_ROOT=/opt/cycle_server
+    unzip $CS_ROOT/tools/cyclecloud-cli.zip
+    pushd cyclecloud-cli-installer
+    ./install.sh --system
+    popd
+    # Update properties
+    sed -i 's/webServerMaxHeapSize\=2048M/webServerMaxHeapSize\=4096M/' $CS_ROOT/config/cycle_server.properties
+    sed -i 's/webServerPort\=8080/webServerPort\=80/' $CS_ROOT/config/cycle_server.properties
+    sed -i 's/webServerSslPort\=8443/webServerSslPort\=443/' $CS_ROOT/config/cycle_server.properties
+    sed -i 's/webServerEnableHttps\=false/webServerEnableHttps=true/' $CS_ROOT/config/cycle_server.properties
+    touch /tmp/cli_installed
+  args:
+    creates: /tmp/cli_installed
+
+- name: stop cycle_server
+  service:
+    name: cycle_server
+    state: stopped
+
 - name: debug
   debug:
     msg:

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -10,11 +10,15 @@
 
 # setup CycleCloud. Ported from https://github.com/Azure/cyclecloud-marketplace-image/blob/main/scripts/setup_cyclecloud.sh
 
+- name: debug
+  debug:
+    msg:
+      - "cc_version={{cc_version}}"
+
 - name: Update packages marked for security
   yum:
     state: latest
     security: yes
-
 
 - name: install AZ CLI repo
   shell: |
@@ -61,15 +65,17 @@
 
 - name: Install pre-reqs packages
   yum:
-    name:
-      - azure-cli
-      - dnsmasq
+    name: azure-cli, dnsmasq
     state: present
 
-- name: Install CycleCloud packages
+- name: Install CycleCloud
   yum:
-    name:
-      - cyclecloud8
+    name: "cyclecloud8-{{cc_version}}"
+    state: present
+
+- name: Install Jetpack
+  yum:
+    name: "jetpack8-{{cc_version}}"
     state: present
 
 - name: Create a data record for azhop and start cycleserver
@@ -109,25 +115,6 @@
   service:
     name: cycle_server
     state: stopped
-
-- name: debug
-  debug:
-    msg:
-      - "cc_jetpack_url={{cc_rpms_jetpack}}"
-      - "cc_update_url={{cc_rpms_cycle}}"
-  when: cc_rpms_cycle is defined
-
-- name: Update CycleCloud RPM
-  yum:
-    name: "{{cc_rpms_cycle}}"
-    state: present
-  when: cc_rpms_cycle is defined
-
-- name: Update Jetpack RPM
-  yum:
-    name: "{{cc_rpms_jetpack}}"
-    state: present
-  when: cc_rpms_jetpack is defined
 
 - name: Update cycle server properties
   shell: |

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -59,13 +59,17 @@
   args:
     creates: /tmp/data_disk_mounted
 
-
-- name: Install cyclecloud packages
+- name: Install pre-reqs packages
   yum:
     name:
       - azure-cli
-      - cyclecloud
       - dnsmasq
+    state: present
+
+- name: Install CycleCloud packages
+  yum:
+    name:
+      - cyclecloud8
     state: present
 
 - name: Create a data record for azhop and start cycleserver

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -10,55 +10,24 @@ resource "azurerm_network_interface" "ccportal-nic" {
   }
 }
 
-resource "azurerm_virtual_machine" "ccportal" {
-  name                  = "ccportal"
-  location              = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
-  resource_group_name   = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
-  vm_size               = try(local.configuration_yml["cyclecloud"].vm_size, "Standard_D2s_v3")
+resource "azurerm_linux_virtual_machine" "ccportal" {
+  name                = "ccportal"
+  location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  size                = try(local.configuration_yml["cyclecloud"].vm_size, "Standard_B2ms")
+  admin_username      = local.admin_username
   network_interface_ids = [
     azurerm_network_interface.ccportal-nic.id,
   ]
 
-  os_profile {
-    computer_name  = "ccportal"
-    admin_username = local.admin_username
+  admin_ssh_key {
+    username   = local.admin_username
+    public_key = tls_private_key.internal.public_key_openssh
   }
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/${local.admin_username}/.ssh/authorized_keys"
-      key_data = tls_private_key.internal.public_key_openssh
-    }
-  }
-
-  storage_os_disk {
-    name              = "ccportal-osdisk"
-    create_option     = "FromImage"
-    caching           = "ReadWrite"
-    managed_disk_type = "Standard_LRS"
-  }
-
-  storage_image_reference {
-    publisher = try(local.configuration_yml["cyclecloud"].image.publisher,"azurecyclecloud")
-    offer     = try(local.configuration_yml["cyclecloud"].image.offer, "azure-cyclecloud")
-    sku       = try(local.configuration_yml["cyclecloud"].image.sku, "cyclecloud8")
-    version   = try(local.configuration_yml["cyclecloud"].image.version, "8.2.120211111")
-  }
-
-  plan {
-    name      = try(local.configuration_yml["cyclecloud"].plan.name, "cyclecloud8")
-    publisher = try(local.configuration_yml["cyclecloud"].plan.publisher, "azurecyclecloud")
-    product   = try(local.configuration_yml["cyclecloud"].plan.product, "azure-cyclecloud")
-  }
-
-  storage_data_disk {
-    lun               = 0
-    name              = "ccportal-datadisk"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Premium_LRS"
-    disk_size_gb      = 128
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
   identity {
@@ -66,7 +35,37 @@ resource "azurerm_virtual_machine" "ccportal" {
     identity_ids = [ azurerm_user_assigned_identity.ccportal.id ]
   }
 
-  #depends_on = [azurerm_network_interface_application_security_group_association.ccportal-asg-asso]
+  source_image_reference {
+    publisher = local.base_image_reference.publisher
+    offer     = local.base_image_reference.offer
+    sku       = local.base_image_reference.sku
+    version   = local.base_image_reference.version
+  }
+
+  dynamic "plan" {
+    for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []
+    content {
+        name      = local.base_image_plan.name
+        publisher = local.base_image_plan.publisher
+        product   = local.base_image_plan.product
+    }
+  }
+}
+
+resource "azurerm_managed_disk" "ccportal_datadisk" {
+  name                 = "ccportal-datadisk"
+  location             = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  resource_group_name  = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 128
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "ccportal" {
+  managed_disk_id    = azurerm_managed_disk.ccportal_datadisk.id
+  virtual_machine_id = azurerm_linux_virtual_machine.ccportal.id
+  lun                = "0"
+  caching            = "ReadWrite"
 }
 
 data "azurerm_role_definition" "contributor" {


### PR DESCRIPTION
Instead of using the CycleCloud marketplace image, install it from RPMs.
- remove the CycleCloud image reference
- remove the CycleCloud plan
- use Linux virtual VM in Terraform instead of the legacy Virtual VM resource provider
- add a version property for CycleCloud in the configuration file
- update pipelines to move add_users after ccportal configuration

close #823 

## Breaking Change
This PR will redeploy a new ccportal instance