### PR TITLE
Allow VM image reference or image id to be provided in the configuration file

### DIFF
--- a/.github/workflows/configs/integration.yml
+++ b/.github/workflows/configs/integration.yml
@@ -73,6 +73,10 @@ locked_down_network:
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
   public_ip: true # Enable public IP creation for Jumpbox, OnDemand and create images. Default to true
 
+# Base image configuration. Can be either an image reference or an image_id from the image registry or a custom managed image
+linux_base_image: "OpenLogic:CentOS:7_9-gen2:latest" # publisher:offer:sku:version or image_id
+windows_base_image: "MicrosoftWindowsServer:WindowsServer:2016-Datacenter-smalldisk:latest" # publisher:offer:sku:version or image_id
+
 jumpbox:
   vm_size: Standard_B2ms
   ssh_port: 2222 # SSH port used on the public IP, default to 22

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -84,6 +84,11 @@ locked_down_network:
   enforce: false
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
   public_ip: true # Enable public IP creation for Jumpbox, OnDemand and create images. Default to true
+
+# Base image configuration. Can be either an image reference or an image_id from the image registry or a custom managed image
+linux_base_image: "OpenLogic:CentOS:7_9-gen2:latest" # publisher:offer:sku:version or image_id
+windows_base_image: "MicrosoftWindowsServer:WindowsServer:2016-Datacenter-smalldisk:latest" # publisher:offer:sku:version or image_id
+
 # Jumpbox VM configuration
 jumpbox:
   vm_size: Standard_B2ms

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -89,6 +89,11 @@ locked_down_network:
   enforce: false
 #   grant_access_from: [a.b.c.d] # Array of CIDR to grant access from, see https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#grant-access-from-an-internet-ip-range
   public_ip: true # Enable public IP creation for Jumpbox, OnDemand and create images. Default to true
+
+# Base image configuration. Can be either an image reference or an image_id from the image registry or a custom managed image
+linux_base_image: "OpenLogic:CentOS:7_9-gen2:latest" # publisher:offer:sku:version or image_id
+windows_base_image: "MicrosoftWindowsServer:WindowsServer:2016-Datacenter-smalldisk:latest" # publisher:offer:sku:version or image_id
+
 # Jumpbox VM configuration
 jumpbox:
   vm_size: Standard_B2ms

--- a/tf/ad.tf
+++ b/tf/ad.tf
@@ -32,12 +32,18 @@ resource "azurerm_windows_virtual_machine" "ad" {
     storage_account_type = "StandardSSD_LRS"
   }
 
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter-smalldisk"
-    version   = "latest"
+  dynamic "source_image_reference" {
+    for_each = local.use_windows_image_id ? [] : [1]
+    content {
+      publisher = local.windows_base_image_reference.publisher
+      offer     = local.windows_base_image_reference.offer
+      sku       = local.windows_base_image_reference.sku
+      version   = local.windows_base_image_reference.version
+    }
   }
+
+  source_image_id = local.windows_image_id
+
 }
 
 resource "azurerm_network_interface_application_security_group_association" "ad-asg-asso" {

--- a/tf/ccportal.tf
+++ b/tf/ccportal.tf
@@ -35,13 +35,17 @@ resource "azurerm_linux_virtual_machine" "ccportal" {
     identity_ids = [ azurerm_user_assigned_identity.ccportal.id ]
   }
 
-  source_image_reference {
-    publisher = local.base_image_reference.publisher
-    offer     = local.base_image_reference.offer
-    sku       = local.base_image_reference.sku
-    version   = local.base_image_reference.version
+  dynamic "source_image_reference" {
+    for_each = local.use_linux_image_id ? [] : [1]
+    content {
+      publisher = local.linux_base_image_reference.publisher
+      offer     = local.linux_base_image_reference.offer
+      sku       = local.linux_base_image_reference.sku
+      version   = local.linux_base_image_reference.version
+    }
   }
 
+  source_image_id = local.linux_image_id
   dynamic "plan" {
     for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []
     content {

--- a/tf/grafana.tf
+++ b/tf/grafana.tf
@@ -30,12 +30,17 @@ resource "azurerm_linux_virtual_machine" "grafana" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_reference {
-    publisher = local.base_image_reference.publisher
-    offer     = local.base_image_reference.offer
-    sku       = local.base_image_reference.sku
-    version   = local.base_image_reference.version
+  dynamic "source_image_reference" {
+    for_each = local.use_linux_image_id ? [] : [1]
+    content {
+      publisher = local.linux_base_image_reference.publisher
+      offer     = local.linux_base_image_reference.offer
+      sku       = local.linux_base_image_reference.sku
+      version   = local.linux_base_image_reference.version
+    }
   }
+
+  source_image_id = local.linux_image_id
 
   dynamic "plan" {
     for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []

--- a/tf/jumpbox.tf
+++ b/tf/jumpbox.tf
@@ -40,13 +40,17 @@ resource "azurerm_linux_virtual_machine" "jumpbox" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_reference {
-    publisher = local.base_image_reference.publisher
-    offer     = local.base_image_reference.offer
-    sku       = local.base_image_reference.sku
-    version   = local.base_image_reference.version
+  dynamic "source_image_reference" {
+    for_each = local.use_linux_image_id ? [] : [1]
+    content {
+      publisher = local.linux_base_image_reference.publisher
+      offer     = local.linux_base_image_reference.offer
+      sku       = local.linux_base_image_reference.sku
+      version   = local.linux_base_image_reference.version
+    }
   }
 
+  source_image_id = local.linux_image_id
   dynamic "plan" {
     for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []
     content {

--- a/tf/ondemand.tf
+++ b/tf/ondemand.tf
@@ -41,12 +41,17 @@ resource "azurerm_linux_virtual_machine" "ondemand" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_reference {
-    publisher = local.base_image_reference.publisher
-    offer     = local.base_image_reference.offer
-    sku       = local.base_image_reference.sku
-    version   = local.base_image_reference.version
+  dynamic "source_image_reference" {
+    for_each = local.use_linux_image_id ? [] : [1]
+    content {
+      publisher = local.linux_base_image_reference.publisher
+      offer     = local.linux_base_image_reference.offer
+      sku       = local.linux_base_image_reference.sku
+      version   = local.linux_base_image_reference.version
+    }
   }
+
+  source_image_id = local.linux_image_id
   dynamic "plan" {
     for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []
     content {

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -108,3 +108,7 @@ data "local_file" "ci_jumpbox" {
   filename = "${path.root}/cloud-init/jumpbox.yml"
   depends_on = [local_file.ci_jumpbox]
 }
+
+# output "use_linux_image_reference" {
+#   value = local.use_linux_image_reference
+# }

--- a/tf/scheduler.tf
+++ b/tf/scheduler.tf
@@ -30,12 +30,17 @@ resource "azurerm_linux_virtual_machine" "scheduler" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_reference {
-    publisher = local.base_image_reference.publisher
-    offer     = local.base_image_reference.offer
-    sku       = local.base_image_reference.sku
-    version   = local.base_image_reference.version
+  dynamic "source_image_reference" {
+    for_each = local.use_linux_image_id ? [] : [1]
+    content {
+      publisher = local.linux_base_image_reference.publisher
+      offer     = local.linux_base_image_reference.offer
+      sku       = local.linux_base_image_reference.sku
+      version   = local.linux_base_image_reference.version
+    }
   }
+
+  source_image_id = local.linux_image_id
   dynamic "plan" {
     for_each = try (length(local.base_image_plan.name) > 0, false) ? [1] : []
     content {


### PR DESCRIPTION
- added linux_base_image and windows_base_image parameter in the configuration file
- build dynamic content in the terraform based on which kind of image to be used
- Only Lustre VMs are not covered by this change

close #813 