### PR TITLE
Use latest certifi version supporting Python 2

### DIFF
--- a/playbooks/roles/influxdb/tasks/main.yml
+++ b/playbooks/roles/influxdb/tasks/main.yml
@@ -19,6 +19,7 @@
 - name: Install required pip packages
   pip:
     name: 
+    - certifi==2021.10.8
     - influxdb
 
 - name: Start and enable the influxdb service


### PR DESCRIPTION
The `influxdb` Python package depends on `certifi`.
Pip will automatically install the latest `certifi` available version which does not support Python 2 anymore, causing a syntax error when the `influxdb` package is imported.

Solution: force pip to install the latest version of `certifi` that still supports Python 2 