### PR TITLE
don't check certificate when downloading VirtualGL.repo

### DIFF
--- a/packer/scripts/centos/interactive-desktop-3d.sh
+++ b/packer/scripts/centos/interactive-desktop-3d.sh
@@ -17,7 +17,7 @@ yum groupinstall -y xfce
 yum install -y https://netix.dl.sourceforge.net/project/turbovnc/2.2.5/turbovnc-2.2.5.x86_64.rpm
 yum install -y https://cbs.centos.org/kojifiles/packages/python-websockify/0.8.0/13.el7/noarch/python2-websockify-0.8.0-13.el7.noarch.rpm
 
-wget "https://virtualgl.org/pmwiki/uploads/Downloads/VirtualGL.repo" -O /etc/yum.repos.d/VirtualGL.repo
+wget --no-check-certificate "https://virtualgl.com/pmwiki/uploads/Downloads/VirtualGL.repo" -O /etc/yum.repos.d/VirtualGL.repo
 
 yum install -y VirtualGL turbojpeg xorg-x11-apps
 /usr/bin/vglserver_config -config +s +f -t


### PR DESCRIPTION
certificate appears to be wrong and VirtualGL.repo won't be downloaded, ending in installing the wrong version of VirtualGL

close #928 