### PR TITLE
Users groups

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -161,7 +161,8 @@ users:
   # name: username
   # uid: uniqueid
   # shell: /bin/bash # default to /bin/bash
-  # home: /anfhome/<user_name> # default to /homedir_mountpoint/user_name  
+  # home: /anfhome/<user_name> # default to /homedir_mountpoint/user_name
+  # groups: list of groups the user belongs to
   - { name: clusteradmin, uid: 10001, groups: [5001, 6000, 6001] }
   - { name: clusteruser, uid: 10002 }
   - { name: user1, uid: 10003, groups: [6000] }
@@ -171,10 +172,12 @@ usergroups:
 # These groups can’t be changed
   - name: Domain Users # All users will be added to this one by default
     gid: 5000
-  - name: az-hop-admins # For users with azhop admin privilege
+  - name: az-hop-admins
     gid: 5001
-  - name: az-hop-localadmins # For users with sudo right on nodes
+    description: "For users with azhop admin privileges"
+  - name: az-hop-localadmins
     gid: 5002
+    description: "For users with sudo right or local admin right on nodes"
 # For custom groups use gid >= 6000
   - name: project1 # For project1 users
     gid: 6000

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -160,17 +160,26 @@ lustre:
 users:
   # name: username
   # uid: uniqueid
-  # gid: 5000
   # shell: /bin/bash # default to /bin/bash
-  # home: /anfhome/<user_name> # default to /homedir_mountpoint/user_name
-  # admin: false # true will allow user to have cluster admin privilege - false by default
-  # sudo: true # Allow sudo access on cluster compute nodes - false by default
-  - { name: clusteradmin, uid: 10001, gid: 5000, admin: true, sudo: true }
-  - { name: clusteruser, uid: 10002, gid: 5000 }
-groups: # Not used today => To be used in the future
-  - name: users
-    gid: 5000
+  # home: /anfhome/<user_name> # default to /homedir_mountpoint/user_name  
+  - { name: clusteradmin, uid: 10001, groups: [5001, 6000, 6001] }
+  - { name: clusteruser, uid: 10002 }
+  - { name: user1, uid: 10003, groups: [6000] }
+  - { name: user2, uid: 10004, groups: [6001] }
 
+usergroups:
+# These groups can’t be changed
+  - name: Domain Users # All users will be added to this one by default
+    gid: 5000
+  - name: az-hop-admins # For users with azhop admin privilege
+    gid: 5001
+  - name: az-hop-localadmins # For users with sudo right on nodes
+    gid: 5002
+# For custom groups use gid >= 6000
+  - name: project1 # For project1 users
+    gid: 6000
+  - name: project2 # For project2 users
+    gid: 6001
 
 # Enable cvmfs-eessi - disabled by default
 # cvmfs_eessi:

--- a/docs/deploy/add_users.md
+++ b/docs/deploy/add_users.md
@@ -5,15 +5,36 @@ Adding users is done in four steps :
 - run the `add_users` Ansible playbook
 - run the `cccluster` playbook to update the Cycle project files
 
-
+You can specify in which groups users belongs to but at least they are all in the `Domain Users (gid: 5000)` domain group. By default there are built-in groups you can't change names otherwise things will break :
+- `Domain Users` : All users will be added to this one by default
+- `az-hop-admins` :  For users with azhop admin privileges like starting/stopping nodes or editing grafana dashboards
+- `az-hop-localadmins` : For users with Linux sudo right or Windows localadmin right on compute or viz nodes
 ## Add users in the configuration file
 
-Open the configuration file used to deploy your environment and add new users in the `users` dictionnary like below :
+Open the configuration file used to deploy your environment and add new users in the `users` dictionnary, and configure `usergroups` like below :
 
 ```yml
 users:
-  - { name: user1, uid: 10001, gid: 5000, admin: true, sudo: true }
-  - { name: user2, uid: 10002, gid: 5000 }
+  - { name: hpcuser,   uid: 10001, groups: [6000] }
+  - { name: adminuser, uid: 10002, groups: [5001, 5002, 6000, 6001] }
+  - { name: user1, uid: 10004, groups: [6000] }
+  - { name: user2, uid: 10005, groups: [6001] }
+
+usergroups:
+  - name: Domain Users # All users will be added to this one by default
+    gid: 5000
+  - name: az-hop-admins # For users with azhop admin privilege
+    gid: 5001
+    description: "For users with azhop admin privileges"
+  - name: az-hop-localadmins # For users with sudo right on nodes
+    gid: 5002
+    description: "For users with sudo right or local admin right on nodes"
+  - name: project1 # For project1 users
+    gid: 6000
+    description: Members of project1
+  - name: project2 # For project2 users
+    gid: 6001
+    description: Members of project2
 ```
 
 ## Create users passwords

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -164,16 +164,29 @@ lustre:
 users:
   # name: username
   # uid: uniqueid
-  # gid: 5000
   # shell: /bin/bash # default to /bin/bash
   # home: /anfhome/<user_name> # default to /homedir_mountpoint/user_name
-  # admin: false # true will allow user to have cluster admin privilege - false by default
-  # sudo: true # Allow sudo access on cluster compute nodes - false by default
-  - { name: clusteradmin, uid: 10001, gid: 5000, admin: true, sudo: true }
-  - { name: clusteruser, uid: 10002, gid: 5000 }
-groups: # Not used today => To be used in the future
-  - name: users
+  # groups: list of groups the user belongs to
+  - { name: clusteradmin, uid: 10001, groups: [5001, 6000, 6001] }
+  - { name: clusteruser, uid: 10002 }
+  - { name: user1, uid: 10003, groups: [6000] }
+  - { name: user2, uid: 10004, groups: [6001] }
+
+usergroups:
+# These groups can’t be changed
+  - name: Domain Users # All users will be added to this one by default
     gid: 5000
+  - name: az-hop-admins
+    gid: 5001
+    description: "For users with azhop admin privileges"
+  - name: az-hop-localadmins
+    gid: 5002
+    description: "For users with sudo right or local admin right on nodes"
+# For custom groups use gid >= 6000
+  - name: project1 # For project1 users
+    gid: 6000
+  - name: project2 # For project2 users
+    gid: 6001
 
 # Enable cvmfs-eessi - disabled by default
 # cvmfs_eessi:

--- a/playbooks/ad.yml
+++ b/playbooks/ad.yml
@@ -64,7 +64,7 @@
         community.windows.win_domain_group:
           name: Domain Users
           attributes:
-            gidnumber: 5000
+            gidnumber: "{{ (usergroups | selectattr('name', 'match', 'Domain Users') | map(attribute='gid')) | default(5000, true) }}"
 
       - name: Disable password expiration
         win_domain_user:
@@ -83,19 +83,42 @@
         with_items: '{{dns.forwarders}}'
         when: dns.forwarders is defined
 
-      - name: Add az-hop admin group
-        community.windows.win_domain_group:
-          name: az-hop-admins
-          state: present
-          description: Members of this group can perform administrative tasks on the az-hop environment
-          scope: domainlocal
+      # - name: Add azhop admin group
+      #   community.windows.win_domain_group:
+      #     name: azhop-admins
+      #     state: present
+      #     description: Members of this group can perform administrative tasks on the az-hop environment
+      #     scope: domainlocal
+      #     attributes:
+      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'azhop-admins') | map(attribute='gid')) | default(5001, true) }}"
 
-      - name: Add az-hop local admin group
+      # - name: Add azhop local admin group
+      #   community.windows.win_domain_group:
+      #     name: azhop-localadmins
+      #     state: present
+      #     description: Members of this group are in the administrators group of Windows nodes
+      #     scope: domainlocal
+      #     attributes:
+      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'azhop-localadmins') | map(attribute='gid')) | default(5002, true) }}"
+
+      - name: Update azhop groups gidnumber
         community.windows.win_domain_group:
-          name: az-hop-localadmins
+          name: '{{item.name}}'
           state: present
-          description: Members of this group are in the administrators group of Windows nodes
           scope: domainlocal
+          attributes:
+            gidnumber: '{{item.gid}}'
+        loop: "{{usergroups  | selectattr('gid', 'ge', 5001) | selectattr('gid', 'lt', 6000) }}"
+
+      - name: Add custom groups
+        community.windows.win_domain_group:
+          name: '{{item.name}}'
+          state: present
+          description: '{{item.description | default("Custom azhop group - item.name")}}'
+          scope: domainlocal
+          attributes:
+            gidnumber: '{{item.gid}}'
+        loop: "{{usergroups  | selectattr('gid', 'ge', 6000) }}"
 
     always:
       - name: close session on local port

--- a/playbooks/ad.yml
+++ b/playbooks/ad.yml
@@ -85,40 +85,41 @@
 
       # - name: Add azhop admin group
       #   community.windows.win_domain_group:
-      #     name: azhop-admins
+      #     name: az-hop-admins
       #     state: present
       #     description: Members of this group can perform administrative tasks on the az-hop environment
       #     scope: domainlocal
       #     attributes:
-      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'azhop-admins') | map(attribute='gid')) | default(5001, true) }}"
+      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'az-hop-admins') | map(attribute='gid')) | default(5001, true) }}"
 
       # - name: Add azhop local admin group
       #   community.windows.win_domain_group:
-      #     name: azhop-localadmins
+      #     name: az-hop-localadmins
       #     state: present
       #     description: Members of this group are in the administrators group of Windows nodes
       #     scope: domainlocal
       #     attributes:
-      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'azhop-localadmins') | map(attribute='gid')) | default(5002, true) }}"
+      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'az-hop-localadmins') | map(attribute='gid')) | default(5002, true) }}"
 
       - name: Update azhop groups gidnumber
         community.windows.win_domain_group:
           name: '{{item.name}}'
           state: present
+          description: '{{item.description | default("az-hop group - item.name")}}'
           scope: domainlocal
           attributes:
             gidnumber: '{{item.gid}}'
-        loop: "{{usergroups  | selectattr('gid', 'ge', 5001) | selectattr('gid', 'lt', 6000) }}"
+        loop: "{{usergroups  | selectattr('gid', 'ge', 5001) }}"
 
-      - name: Add custom groups
-        community.windows.win_domain_group:
-          name: '{{item.name}}'
-          state: present
-          description: '{{item.description | default("Custom azhop group - item.name")}}'
-          scope: domainlocal
-          attributes:
-            gidnumber: '{{item.gid}}'
-        loop: "{{usergroups  | selectattr('gid', 'ge', 6000) }}"
+      # - name: Add custom groups
+      #   community.windows.win_domain_group:
+      #     name: '{{item.name}}'
+      #     state: present
+      #     description: '{{item.description | default("Custom azhop group - item.name")}}'
+      #     scope: domainlocal
+      #     attributes:
+      #       gidnumber: '{{item.gid}}'
+      #   loop: "{{usergroups  | selectattr('gid', 'ge', 6000) }}"
 
     always:
       - name: close session on local port

--- a/playbooks/ad.yml
+++ b/playbooks/ad.yml
@@ -83,24 +83,6 @@
         with_items: '{{dns.forwarders}}'
         when: dns.forwarders is defined
 
-      # - name: Add azhop admin group
-      #   community.windows.win_domain_group:
-      #     name: az-hop-admins
-      #     state: present
-      #     description: Members of this group can perform administrative tasks on the az-hop environment
-      #     scope: domainlocal
-      #     attributes:
-      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'az-hop-admins') | map(attribute='gid')) | default(5001, true) }}"
-
-      # - name: Add azhop local admin group
-      #   community.windows.win_domain_group:
-      #     name: az-hop-localadmins
-      #     state: present
-      #     description: Members of this group are in the administrators group of Windows nodes
-      #     scope: domainlocal
-      #     attributes:
-      #       gidnumber: "{{ (usergroups | selectattr('name', 'match', 'az-hop-localadmins') | map(attribute='gid')) | default(5002, true) }}"
-
       - name: Update azhop groups gidnumber
         community.windows.win_domain_group:
           name: '{{item.name}}'
@@ -110,16 +92,6 @@
           attributes:
             gidnumber: '{{item.gid}}'
         loop: "{{usergroups  | selectattr('gid', 'ge', 5001) }}"
-
-      # - name: Add custom groups
-      #   community.windows.win_domain_group:
-      #     name: '{{item.name}}'
-      #     state: present
-      #     description: '{{item.description | default("Custom azhop group - item.name")}}'
-      #     scope: domainlocal
-      #     attributes:
-      #       gidnumber: '{{item.gid}}'
-      #   loop: "{{usergroups  | selectattr('gid', 'ge', 6000) }}"
 
     always:
       - name: close session on local port

--- a/playbooks/create_user.yml
+++ b/playbooks/create_user.yml
@@ -2,6 +2,7 @@
   debug:
     msg:
       - "user={{user}}"
+      - "{{ usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | map(attribute='name') }}"
 
 # Remove any forbidden characters from the username so we conform to the keyvaul secret name rules '^[0-9a-zA-Z-]+$'
 - name: Set secretname
@@ -38,7 +39,6 @@
     user_shell: "{{user.shell}}"
   when: user.shell is defined
 
-
 - name: add user
   community.windows.win_domain_user:
     name: "{{ user.name }}"
@@ -54,22 +54,29 @@
       uid: "{{ user.name }}"
       loginShell: "{{ user_shell }}"
       unixhomedirectory: "{{ user_home }}"
-      gidnumber: "{{user.gid}}"
+      gidnumber: "{{ (usergroups | selectattr('name', 'match', 'Domain Users') | map(attribute='gid')) | default(5000, true) }}"
 
-# Add admin users into the az-hop-admins group
-- name: add Admin
+# Add users into groups
+- name: Add users into groups
   community.windows.win_domain_user:
     name: "{{ user.name }}"
     state: present
-    groups:
-      - az-hop-admins
-  when: user.admin | default(false)
+    groups: "{{ usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | map(attribute='name')}}"
 
-# Add users into the az-hop-localadmins group
-- name: add local admin
-  community.windows.win_domain_user:
-    name: "{{ user.name }}"
-    state: present
-    groups:
-      - az-hop-localadmins
-  when: user.sudo | default(false)
+# # Add admin users into the azhop-admins group
+# - name: add Admin
+#   community.windows.win_domain_user:
+#     name: "{{ user.name }}"
+#     state: present
+#     groups:
+#       - azhop-admins
+#   when: user.admin | default(false)
+
+# # Add users into the azhop-localadmins group
+# - name: add local admin
+#   community.windows.win_domain_user:
+#     name: "{{ user.name }}"
+#     state: present
+#     groups:
+#       - azhop-localadmins
+#   when: user.sudo | default(false)

--- a/playbooks/create_user.yml
+++ b/playbooks/create_user.yml
@@ -2,7 +2,8 @@
   debug:
     msg:
       - "user={{user}}"
-      - "{{ usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | map(attribute='name') }}"
+      - "{{ usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | selectattr('name', 'match', 'az-hop-admins') | map(attribute='name') }}"
+#      - "{{ (usergroups | selectattr('name', 'match', 'az-hop-admins') | map(attribute='gid')) | default(5000, true) | selectattr('gid', 'in', (user.groups | default([], true))) }}"
 
 # Remove any forbidden characters from the username so we conform to the keyvaul secret name rules '^[0-9a-zA-Z-]+$'
 - name: Set secretname
@@ -63,20 +64,21 @@
     state: present
     groups: "{{ usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | map(attribute='name')}}"
 
-# # Add admin users into the azhop-admins group
-# - name: add Admin
-#   community.windows.win_domain_user:
-#     name: "{{ user.name }}"
-#     state: present
-#     groups:
-#       - azhop-admins
-#   when: user.admin | default(false)
+#### Block to maintain compatibility with older user properties
+# Add admin users into the azhop-admins group
+- name: add Admin
+  community.windows.win_domain_user:
+    name: "{{ user.name }}"
+    state: present
+    groups:
+      - az-hop-admins
+  when: user.admin | default(false)
 
-# # Add users into the azhop-localadmins group
-# - name: add local admin
-#   community.windows.win_domain_user:
-#     name: "{{ user.name }}"
-#     state: present
-#     groups:
-#       - azhop-localadmins
-#   when: user.sudo | default(false)
+# Add users into the azhop-localadmins group
+- name: add local admin
+  community.windows.win_domain_user:
+    name: "{{ user.name }}"
+    state: present
+    groups:
+      - az-hop-localadmins
+  when: user.sudo | default(false)

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
@@ -10,12 +10,8 @@ chmod 700 -R /mnt/cluster-init
 # FIXME : /mnt/resource doesn't exists on Ubuntu
 chmod 777 /mnt/resource
 
-# Grant sudo for users with sudo privilege
-{% for user in users %}
-{% if user.sudo is defined and user.sudo %}
-echo "{{user.name}} ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers.d/{{ user.name | map('regex_replace', '[^0-9a-zA-Z-]', '')|list|join() }}
-{% endif %}
-{% endfor %}
+# Grant sudo for users in the az-hop-localadmins group
+echo "%az-hop-localadmins@HPC.AZURE ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers.d/az-hop-localadmins
 
 # For any NV instances, reinit the session
 AZHPC_VMSIZE=$(curl -s --noproxy "*" -H Metadata:true "http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15" | jq -r '.vmSize' | tr '[:upper:]' '[:lower:]')

--- a/playbooks/templates/user_record.txt.j2
+++ b/playbooks/templates/user_record.txt.j2
@@ -2,7 +2,7 @@
 AdType = "AuthenticatedUser"
 Name =  "{{ user.name }}"
 Authentication = "active_directory"
-{% if (user.admin is defined) and user.admin %}
+{% if (usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | selectattr('name', 'match', 'az-hop-admins') | map(attribute='name') | count ) > 0 %}
 Roles = {"azhop Cluster Admin"}
 {% else %}
 Roles = {"User"}


### PR DESCRIPTION
- Allow custom users groups to be added in AD and with a GID
- Allow users to be part of several groups
- Added specific az-hop groups for localadmins (sudoers and windows admin) and azhop admins
- Change in cluster-init script, sudoers to allow users in the localdadmins group instead of having to create individual grant for each user
- Updated the CycleCloud users records to match the new group definition
- Updated the config template with the new users and groups schema
- extended documentation in the add_user section to explain groups

close #235 

> Note : There shouldn't be any breaking changes, however it's recommended to update the user list and usersgroups to the new schema