### PR TITLE
fix cyclecloud version discrepancy

### DIFF
--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -36,4 +36,4 @@
       cc_storage: '{{global_cc_storage}}'
       cc_domain: '{{ad_join_domain}}'
       cc_ad_server: '{{ldap_server}}'
-      cc_version: '{{cyclecloud.version | default("8.2.1-1733")}}'
+      cc_version: '{{cyclecloud.version | default("8.2.2-1902")}}'


### PR DESCRIPTION
fixed the issue that if cc version is not set in config.yml, slurm would fail to create nodes