### PR TITLE
Add environment variables for slurmd to allow using PMIx+IB from containers across nodes

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/1-install_pyxis.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/1-install_pyxis.sh.j2
@@ -9,6 +9,3 @@ chmod +x /usr/lib64/slurm/spank_pyxis.so
 
 ln -sfv /sched/plugstack.conf /etc/slurm/plugstack.conf
 ln -sfv /sched/plugstack.conf.d /etc/slurm/plugstack.conf.d
-
-echo Restarting SLURMD...
-systemctl restart slurmd

--- a/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
@@ -23,6 +23,3 @@ cp -fv /usr/share/enroot/hooks.d/50-slurm-pmi.sh /usr/share/enroot/hooks.d/50-sl
 # Add variables for PMIx
 sed -i '/EnvironmentFile/a Environment=PMIX_MCA_ptl=^usock PMIX_MCA_psec=none PMIX_SYSTEM_TMPDIR=/var/empty PMIX_MCA_gds=hash HWLOC_COMPONENTS=-opencl' /usr/lib/systemd/system/slurmd.service
 systemctl daemon-reload
-
-echo Restarting SLURMD...
-systemctl restart slurmd

--- a/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
@@ -20,24 +20,9 @@ EOF
 cp -fv /usr/share/enroot/hooks.d/50-slurm-pmi.sh /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d
 
 [ -d /etc/sysconfig ] || mkdir -pv /etc/sysconfig
-
-SLURM_ENV=/usr/local/sbin/slurm_env.sh
-cat <<EOFEOF > $SLURM_ENV
-#!/bin/bash
-if ! grep PMIX /etc/sysconfig/slurmd ; then
-cat <<EOF >> /etc/sysconfig/slurmd
-
-      PMIX_MCA_ptl=^usock
-      PMIX_MCA_psec=none
-      PMIX_SYSTEM_TMPDIR=/var/empty
-      PMIX_MCA_gds=hash
-      HWLOC_COMPONENTS=-opencl
-EOF
-fi
-EOFEOF
-chmod +x $SLURM_ENV
-echo "*/5 * * * * root $SLURM_ENV" > /etc/cron.d/slurmenv
-$SLURM_ENV
+# Add variables for PMIx
+sed -i '/EnvironmentFile/a Environment=PMIX_MCA_ptl=^usock PMIX_MCA_psec=none PMIX_SYSTEM_TMPDIR=/var/empty PMIX_MCA_gds=hash HWLOC_COMPONENTS=-opencl' /usr/lib/systemd/system/slurmd.service
+systemctl daemon-reload
 
 echo Restarting SLURMD...
 systemctl restart slurmd

--- a/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/enroot/cluster-init/scripts/2-install_enroot.sh.j2
@@ -18,3 +18,26 @@ EOF
 
 # Install extra hooks for PMIx
 cp -fv /usr/share/enroot/hooks.d/50-slurm-pmi.sh /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d
+
+[ -d /etc/sysconfig ] || mkdir -pv /etc/sysconfig
+
+SLURM_ENV=/usr/local/sbin/slurm_env.sh
+cat <<EOFEOF > $SLURM_ENV
+#!/bin/bash
+if ! grep PMIX /etc/sysconfig/slurmd ; then
+cat <<EOF >> /etc/sysconfig/slurmd
+
+      PMIX_MCA_ptl=^usock
+      PMIX_MCA_psec=none
+      PMIX_SYSTEM_TMPDIR=/var/empty
+      PMIX_MCA_gds=hash
+      HWLOC_COMPONENTS=-opencl
+EOF
+fi
+EOFEOF
+chmod +x $SLURM_ENV
+echo "*/5 * * * * root $SLURM_ENV" > /etc/cron.d/slurmenv
+$SLURM_ENV
+
+echo Restarting SLURMD...
+systemctl restart slurmd


### PR DESCRIPTION
add environment variables to slurmd to allow using PMIx+IB from containers across nodes.
using cron to deal with cyclecloud overwriting /etc/sysconfig/slurmd file
