### PR TITLE
Fix MODULEPATH for HPC CentOS image

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
@@ -29,3 +29,6 @@ esac
 if [ ! -d /usr/share/Modules ]; then
     ln -s /usr/share/modules /usr/share/Modules
 fi
+
+# Add modulefiles from HPC CentOS image to module path
+export MODULEPATH=$MODULEPATH:/usr/share/Modules/modulefiles/


### PR DESCRIPTION
fixes #285 

The current `MODULEPATH` on the `azhop-centos79-v2-rdma-gpgpu` az-hop image is
```
$ echo $MODULEPATH
/etc/modulefiles:/usr/share/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
```
However, `/usr/share/modulefiles` is actually empty
```
$ ls /usr/share/modulefiles/
$
```

The actual modules of the CentOS-HPC image are here:
```
$ ls /usr/share/Modules/modulefiles/
amd  dot  gcc-9.2.0  module-git  module-info  modulefiles  modules  mpi  null  use.own
```

P.S. I don't know where the `/Linux`, `/Core`, ... additions to the `$MODULEPATH` come from. It seems to me they don't apply to the HPC CentOS image.