### PR TITLE
remove anfhome mount from slurm cluster template

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -65,13 +65,6 @@ Autoscale = true
         address = {{mounts.home.server}}
         #options =
 
-        [[[configuration cyclecloud.mounts.nfs_anfhome]]]
-        type = nfs
-        mountpoint = /anfhome
-        export_path = {{mounts.home.export}}
-        address = {{mounts.home.server}}
-        #options =
-
     [[node nodearraybase]]
     Abstract = true
         [[[configuration]]]


### PR DESCRIPTION
removing the mount as it's already done in the cluster-init scripts. Maintaining parity with the OpenPBS template

#close 1012