### PR TITLE
Build Windows Image without public IP

### DIFF
--- a/packer/azhop-win10.json
+++ b/packer/azhop-win10.json
@@ -20,6 +20,11 @@
             "winrm_username": "packer",
 
             "build_resource_group_name": "{{user `var_resource_group`}}",
+            "private_virtual_network_with_public_ip": "{{user `var_private_virtual_network_with_public_ip`}}",
+            "virtual_network_name": "{{user `var_virtual_network_name`}}",
+            "virtual_network_subnet_name": "{{user `var_virtual_network_subnet_name`}}",
+            "virtual_network_resource_group_name": "{{user `var_virtual_network_resource_group_name`}}",
+            "build_key_vault_name": "{{user `var_key_vault_name`}}",
             "cloud_environment_name": "{{user `var_cloud_env`}}"
         }
     ],

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -8,6 +8,7 @@ resource "azurerm_key_vault" "azhop" {
   location                    = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name         = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   enabled_for_disk_encryption = true
+  enabled_for_deployment      = true
   tenant_id                   = local.tenant_id
   # soft delete is enabled by default now (2021-8-25), with 90 days retention
   # soft_delete_enabled         = true

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -205,7 +205,6 @@ locals {
         Web = ["443", "80"]
         Ssh    = ["22"]
         Public_Ssh = [local.jumpbox_ssh_port]
-        Socks = ["5985"]
         # DNS, Kerberos, RpcMapper, Ldap, Smb, KerberosPass, LdapSsl, LdapGc, LdapGcSsl, AD Web Services, RpcSam
         DomainControlerTcp = ["53", "88", "135", "389", "445", "464", "686", "3268", "3269", "9389", "49152-65535"]
         # DNS, Kerberos, W32Time, NetBIOS, Ldap, KerberosPass, LdapSsl
@@ -226,6 +225,8 @@ locals {
         MySQL = ["3306", "33060"],
         # Guacamole
         Guacamole = ["8080"]
+        # WinRM
+        WinRM = ["5985", "5986"]
     }
 
     # Array of NSG rules to be applied on the common NSG
@@ -300,7 +301,7 @@ locals {
         AllowGrafanaIn              = ["510", "Inbound", "Allow", "Tcp", "Grafana",            "asg/asg-ondemand",          "asg/asg-grafana"],
 
         # Admin and Deployment
-        AllowSocksIn                = ["520", "Inbound", "Allow", "Tcp", "Socks",              "asg/asg-jumpbox",          "asg/asg-rdp"],
+        AllowWinRMIn                = ["520", "Inbound", "Allow", "Tcp", "WinRM",              "asg/asg-jumpbox",          "asg/asg-rdp"],
         AllowRdpIn                  = ["550", "Inbound", "Allow", "Tcp", "Rdp",                "asg/asg-jumpbox",          "asg/asg-rdp"],
 
         # Guacamole
@@ -378,7 +379,7 @@ locals {
 
         # Admin and Deployment
         AllowRdpOut                 = ["570", "Outbound", "Allow", "Tcp", "Rdp",                "asg/asg-jumpbox",          "asg/asg-rdp"],
-        AllowSocksOut               = ["580", "Outbound", "Allow", "Tcp", "Socks",              "asg/asg-jumpbox",          "asg/asg-rdp"],
+        AllowWinRMOut               = ["580", "Outbound", "Allow", "Tcp", "WinRM",              "asg/asg-jumpbox",          "asg/asg-rdp"],
         AllowDnsOut                 = ["590", "Outbound", "Allow", "*",   "Dns",                "tag/VirtualNetwork",       "tag/VirtualNetwork"],
 
         # Guacamole
@@ -398,6 +399,7 @@ locals {
     hub_nsg_rules = {
         AllowHubSshIn          = ["200", "Inbound", "Allow", "Tcp", "Public_Ssh",               "tag/VirtualNetwork", "asg/asg-jumpbox"],
         AllowHubHttpIn         = ["210", "Inbound", "Allow", "Tcp", "Web",                      "tag/VirtualNetwork", "asg/asg-ondemand"],
+        AllowPackerWinRMIn     = ["560", "Inbound", "Allow", "Tcp", "WinRM",                    "tag/VirtualNetwork", "subnet/compute"],
     }
 
     bastion_nsg_rules = {


### PR DESCRIPTION
- use azhop keyvault instead of packer keyvault for windows vm
- don't use public IP for windows VM
- added an new NSG for WinRM
- enable the azhop provisionned KeyVault for deployment

close #869 