### PR TITLE
fix path to roles in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-roles_path = roles
+roles_path = playbooks/roles
 forks = 128
 #strategy = free
 #callback_whitelist = profile_roles


### PR DESCRIPTION
This is relevant for using `ansible-galaxy install`.