### PR TITLE
add a PBS job submission hook

### DIFF
--- a/playbooks/roles/pbsclient/tasks/main.yml
+++ b/playbooks/roles/pbsclient/tasks/main.yml
@@ -14,14 +14,14 @@
 
 - name: Download PBS RPMs
   unarchive:
-    src: https://github.com/PBSPro/pbspro/releases/download/v19.1.1/pbspro_19.1.1.centos7.zip
+    src: https://github.com/PBSPro/pbspro/releases/download/v{{openpbs_version}}/pbspro_{{openpbs_version}}.centos7.zip
     dest: /mnt/resource
     remote_src: yes
 
 - name: install PBS Client
   yum: 
     name:
-      - /mnt/resource/pbspro_19.1.1.centos7/pbspro-execution-19.1.1-0.x86_64.rpm
+      - /mnt/resource/pbspro_{{openpbs_version}}.centos7/pbspro-execution-{{openpbs_version}}-0.x86_64.rpm
     state: present
 
 - name: Configure PBS server name in pbs.conf

--- a/playbooks/roles/pbsclient/vars/main.yml
+++ b/playbooks/roles/pbsclient/vars/main.yml
@@ -1,0 +1,1 @@
+openpbs_version: 19.1.1

--- a/playbooks/roles/pbsserver/files/submit-hook.py
+++ b/playbooks/roles/pbsserver/files/submit-hook.py
@@ -1,0 +1,34 @@
+# submit hook
+# check if job environment variables doesn't contains single quotes, and if so reject the job
+
+# To install run
+# qmgr -c "create hook submit"
+# qmgr -c "import hook submit application/x-python default submit-hook.py"
+# qmgr -c "set hook submit event = queuejob"
+
+import sys
+import pbs
+import subprocess
+
+## Main program
+try:
+    je = pbs.event()
+    jb = je.job
+
+    for var in jb.Variable_List:
+        quote = jb.Variable_List[var].find("'")
+        if quote != -1:
+            pbs.logmsg(pbs.LOG_DEBUG, "rejecting job because of an unsupported quote in environment variable %s" % var)
+            je.reject("unsupported quote in environment variable %s" % var)
+
+    je.accept()
+
+except SystemExit:
+    pass
+
+except:
+   e=sys.exc_info()
+   pbs.logmsg(pbs.LOG_DEBUG, "Error - type:  %s"%(e[0]))
+   pbs.logmsg(pbs.LOG_DEBUG, "Error - value:  %s"%(e[1]))
+   pbs.logmsg(pbs.LOG_DEBUG, "Error - traceback:  %s"%(e[2]))
+   je.reject("Error submitting job in job submission hook! Contact your Admin")

--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -6,14 +6,14 @@
 
 - name: Download pbspro 
   unarchive:
-    src: https://github.com/PBSPro/pbspro/releases/download/v19.1.1/pbspro_19.1.1.centos7.zip
+    src: https://github.com/PBSPro/pbspro/releases/download/v{{openpbs_version}}/pbspro_{{openpbs_version}}.centos7.zip
     dest: /mnt/resource
     remote_src: yes
 
 - name: Install pbspro
   yum:
     name: 
-      - /mnt/resource/pbspro_19.1.1.centos7/pbspro-server-19.1.1-0.x86_64.rpm
+      - /mnt/resource/pbspro_{{openpbs_version}}.centos7/pbspro-server-{{openpbs_version}}-0.x86_64.rpm
     state: present
 
 - name: Ensure pbs-server is running.

--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -81,6 +81,19 @@
 - name: activate pbs config
   shell: /var/spool/pbs/doqmgr.sh 
 
+- name: Add submission hook
+  copy:
+    src: '{{role_path}}/files/submit-hook.py'
+    dest: /opt/cycle/pbspro/submit-hook.py
+
+- name: Register submission hook
+  shell: |
+    /opt/pbs/bin/qmgr -c "create hook submit"
+    /opt/pbs/bin/qmgr -c "import hook submit application/x-python default submit-hook.py"
+    /opt/pbs/bin/qmgr -c "set hook submit event = queuejob"
+  args:
+    chdir: /opt/cycle/pbspro
+
 - name: Restart pbs-server 
   service: 
     name: pbs

--- a/playbooks/roles/pbsserver/vars/main.yml
+++ b/playbooks/roles/pbsserver/vars/main.yml
@@ -1,1 +1,2 @@
 cyclecloud_pbspro: 2.0.15
+openpbs_version: 19.1.1


### PR DESCRIPTION
This hook will reject any jobs with environment variables containing a single quote. This is due to a bug in qstat malforming JSON document which end into breaking the autoscaler.

close #704 
close #841 