### PR TITLE
disable azsecd service on compute nodes

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
@@ -32,3 +32,7 @@ fi
 
 # Add modulefiles from HPC CentOS image to module path
 export MODULEPATH=$MODULEPATH:/usr/share/Modules/modulefiles/
+
+# Disable the antivirus
+systemctl stop azsecd
+systemctl disable azsecd

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
@@ -34,5 +34,8 @@ fi
 export MODULEPATH=$MODULEPATH:/usr/share/Modules/modulefiles/
 
 # Disable the antivirus
-systemctl stop azsecd
-systemctl disable azsecd
+if [ -a /usr/lib/systemd/system/azsecd.service ] ; then
+  systemctl stop azsecd
+  systemctl disable azsecd
+  echo "Disabled azsecd service"
+fi


### PR DESCRIPTION
disable azsecd service which will launch antivirus scan on the compute nodes