### PR TITLE
disable GPO access control in sssd

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/3-joindomain.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/3-joindomain.sh.j2
@@ -58,6 +58,8 @@ done
 sed -i 's@use_fully_qualified_names.*@use_fully_qualified_names = False@' /etc/sssd/sssd.conf
 sed -i 's@ldap_id_mapping.*@ldap_id_mapping = False@' /etc/sssd/sssd.conf
 
+echo "ad_gpo_access_control = disabled" >> /etc/sssd/sssd.conf
+
 systemctl restart sssd
 systemctl restart sshd
 

--- a/playbooks/roles/domain_join/tasks/main.yml
+++ b/playbooks/roles/domain_join/tasks/main.yml
@@ -61,6 +61,13 @@
     line: 'ldap_id_mapping = False'
   notify: restart sssd
 
+- name: configure sssd - ad_gpo_access_control 
+  lineinfile:
+    path: /etc/sssd/sssd.conf
+    regexp: '^ad_gpo_access_control'
+    line: 'ad_gpo_access_control = disabled'
+  notify: restart sssd
+
 # Thes are the options to set in order to register DNS in the AD
 # hostnamectl set-hostname jumpbox.hpc.azure
 # dyndns_update = true


### PR DESCRIPTION
disabled GPO access control in sssd to avoid overloading the system logs with warnings as suggested in #1074 