### PR TITLE
Dynamic UI when requesting a Linux Desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ playbooks/group_vars/*
 playbooks/image_lookup.yml
 playbooks/remoteviz_image_lookup.yml
 playbooks/*.ok
+playbooks/node_arrays.yml
 
 # ssh keys
 *.pub

--- a/playbooks/cccluster.yml
+++ b/playbooks/cccluster.yml
@@ -27,6 +27,7 @@
     register: password
     become: false
 
+
   - name: Init image lookup file
     shell: |
         echo "image_lookup:" > {{lookup_img_file}}
@@ -116,3 +117,8 @@
       enroot_scratch_dir: '/mnt/resource'
       cvmfs_eessi_enabled: '{{cvmfs_eessi.enabled | default(false)}}'
       cc_enable_remote_winviz: '{{enable_remote_winviz | default(false)}}'
+
+  # Generate the node array core lookup file for ondemand - will be only run if the marker file for ondemand exists
+  - import_tasks: nodearray_lookup.yml
+    vars:
+      marker_file: ood.ok

--- a/playbooks/nodearray_lookup.yml
+++ b/playbooks/nodearray_lookup.yml
@@ -1,0 +1,49 @@
+- name: Check if marker file exists
+  stat:
+    path: '{{ marker_file }}'
+  register: marker
+  delegate_to: localhost
+  connection: local
+
+- name: create node array core lookup file for ondemand
+  block:
+    - name: Set PBS cluster name
+      set_fact:
+        cluster_name: "pbs1"
+      when: (queue_manager == "openpbs")
+
+    - name: Set SLURM cluster name
+      set_fact:
+        cluster_name: "slurm1"
+      when: (queue_manager == "slurm")
+
+    - name: Read User Password from KV
+      command: az keyvault secret show --vault-name {{key_vault}} -n {{users[0].name}}-password --query "value" -o tsv
+      delegate_to: localhost
+      connection: local
+      register: user_password
+      become: false
+
+    - name: Build node core lookup
+      shell: |
+          set -e
+          curl -k -u "{{users[0].name}}:{{user_password.stdout}}" "https://{{ondemand_fqdn}}/cyclecloud/clusters/{{cluster_name}}/status?nodes" | jq '[.nodearrays[] | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount}]' | yq e -P > node_arrays.yml
+      args:
+        executable: /bin/bash
+      delegate_to: localhost
+      connection: local
+      become: false
+
+    - name: create config directory
+      file:
+        path: /etc/ood/config/apps/bc_desktop/config
+        state: directory
+      delegate_to: ondemand
+
+    - name: Copy node_arrays files only if ondemand has been installed
+      copy:
+        src: 'node_arrays.yml'
+        dest: '/etc/ood/config/apps/bc_desktop/config/node_arrays.yml'
+      delegate_to: ondemand
+  when: marker.stat.exists == true
+

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -32,6 +32,10 @@ ood_install_apps:
     version: master
 
 ood_apps:
+  dashboard:
+    env:
+      ood_bc_dynamic_js: true
+
   bc_desktop:
     title: "Linux Desktop"
     cluster: ondemand
@@ -49,27 +53,22 @@ ood_apps:
         help: |
           Select the resource target for the remote desktop session <br>
           - **With GPU** <br>
-            These are standard small GPU nodes for visualization, usually for a single session.<br>
+            These are standard small GPU nodes for visualization for a single user session.<br>
           - **Large With GPU** <br>
-            These are standard large GPU nodes for visualization, usually for multiple sessions sharing the same node.<br>
+            These are standard large GPU nodes for visualization, usually for multiple users sessions sharing the same node.<br>
           - **Without GPU** <br>
-            Same as for **With GPU** but without GPU.
+            Same as for **With GPU** but without a GPU accelerator.
         options:
-         - ["With GPU - Small GPU node for single session", "viz3d"]
-         - ["Large With GPU - Intented for shared sessions", "largeviz3d"]
-         - ["Without GPU - for single session", "viz"]
-        id: 'target'
+         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
+         - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-hide-reservedcores: false, data-max-reservedcores: 48, data-min-reservedcores: 0, data-max-num-hours: 168, data-min-num-hours: 1]
+         - ["Without GPU - for single session", "viz", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
       num_hours:
         widget: "number_field"
-        label: "Maximum duration of your remote session"
+        label: "Maximum duration in hours of your remote session"
         value: 1
         help: |
-          This is the maximum duration of your remote session once started. <br> 
-          Enter a value between 0 and 24. <strong>0 means no limit</strong>.
-        min: 0
-        max: 24
+          This is the maximum duration in hours of your remote session once started. <br> 
         step: 1
-        id: 'hours'
       reservedcores:
         widget: "number_field"
         label: "Maximum number of cores of your remote session"
@@ -77,10 +76,7 @@ ood_apps:
         help: |
           This is the maximum number of cores used on a shared node. <br>
           Enter a value between 0 and 48. <strong>0 means all cores are used</strong>.
-        min: 0
-        max: 48
         step: 1
-        id: 'reservedcores'
 
 host_regex: '[^./]+'
 node_uri: '/node'

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -59,9 +59,15 @@ ood_apps:
           - **Without GPU** <br>
             Same as for **With GPU** but without a GPU accelerator.
         options:
-         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-bucket: true, data-set-bucket: 100, data-max-num-hours: 12, data-min-num-hours: 1]
-         - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-max-num-hours: 168, data-min-num-hours: 1]
-         - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 100, data-max-num-hours: 12, data-min-num-hours: 1]
+         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-bucket: true, data-set-bucket: 100, 
+              data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz3d') | map(attribute='max_hours')) | default(8, true) }}", 
+              data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz3d') | map(attribute='min_hours')) | default(1, true) }}"]
+         - ["Large With GPU - Intented for shared sessions", "largeviz3d", 
+              data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'largeviz3d') | map(attribute='max_hours')) | default(8, true) }}", 
+              data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'largeviz3d') | map(attribute='min_hours')) | default(1, true) }}"]
+         - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 100, 
+              data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='max_hours')) | default(8, true) }}", 
+              data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='min_hours')) | default(1, true) }}"]
         #  - ["With GPU - Small GPU node for single session", "viz3d", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
         #  - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-hide-reservedcores: false, data-max-reservedcores: 48, data-min-reservedcores: 0, data-max-num-hours: 168, data-min-num-hours: 1]
         #  - ["Without GPU - for single session", "viz", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
@@ -78,18 +84,9 @@ ood_apps:
         help: |
           Select how much of the node you want to use <br>
         options:
-         - [" 25 %", "25"]
-         - [" 50 %", "50"]
-         - ["100 %", "100"]
-
-      # reservedcores:
-      #   widget: "number_field"
-      #   label: "Maximum number of cores of your remote session"
-      #   value: 4
-      #   help: |
-      #     This is the maximum number of cores used on a shared node. <br>
-      #     Enter a value between 0 and 48. <strong>0 means all cores are used</strong>.
-      #   step: 1
+         - [" 25 % of the node", "25"]
+         - [" 50 % of the node", "50"]
+         - ["100 % of the node", "100"]
 
 host_regex: '[^./]+'
 node_uri: '/node'

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -44,7 +44,7 @@ ood_apps:
       - desktop
       - target
       - num_hours
-      - reservedcores
+      - bucket
     attributes:
       desktop: xfce
       target:
@@ -59,9 +59,12 @@ ood_apps:
           - **Without GPU** <br>
             Same as for **With GPU** but without a GPU accelerator.
         options:
-         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
-         - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-hide-reservedcores: false, data-max-reservedcores: 48, data-min-reservedcores: 0, data-max-num-hours: 168, data-min-num-hours: 1]
-         - ["Without GPU - for single session", "viz", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
+         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-bucket: true, data-set-bucket: 100, data-max-num-hours: 12, data-min-num-hours: 1]
+         - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-max-num-hours: 168, data-min-num-hours: 1]
+         - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 100, data-max-num-hours: 12, data-min-num-hours: 1]
+        #  - ["With GPU - Small GPU node for single session", "viz3d", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
+        #  - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-hide-reservedcores: false, data-max-reservedcores: 48, data-min-reservedcores: 0, data-max-num-hours: 168, data-min-num-hours: 1]
+        #  - ["Without GPU - for single session", "viz", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
       num_hours:
         widget: "number_field"
         label: "Maximum duration in hours of your remote session"
@@ -69,14 +72,24 @@ ood_apps:
         help: |
           This is the maximum duration in hours of your remote session once started. <br> 
         step: 1
-      reservedcores:
-        widget: "number_field"
-        label: "Maximum number of cores of your remote session"
-        value: 4
+      bucket:
+        widget: "select"
+        label: "Node bucket"
         help: |
-          This is the maximum number of cores used on a shared node. <br>
-          Enter a value between 0 and 48. <strong>0 means all cores are used</strong>.
-        step: 1
+          Select how much of the node you want to use <br>
+        options:
+         - [" 25 %", "25"]
+         - [" 50 %", "50"]
+         - ["100 %", "100"]
+
+      # reservedcores:
+      #   widget: "number_field"
+      #   label: "Maximum number of cores of your remote session"
+      #   value: 4
+      #   help: |
+      #     This is the maximum number of cores used on a shared node. <br>
+      #     Enter a value between 0 and 48. <strong>0 means all cores are used</strong>.
+      #   step: 1
 
 host_regex: '[^./]+'
 node_uri: '/node'

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -68,9 +68,6 @@ ood_apps:
          - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 100, 
               data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='max_hours')) | default(8, true) }}", 
               data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='min_hours')) | default(1, true) }}"]
-        #  - ["With GPU - Small GPU node for single session", "viz3d", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
-        #  - ["Large With GPU - Intented for shared sessions", "largeviz3d", data-hide-reservedcores: false, data-max-reservedcores: 48, data-min-reservedcores: 0, data-max-num-hours: 168, data-min-num-hours: 1]
-        #  - ["Without GPU - for single session", "viz", data-hide-reservedcores: true, data-set-reservedcores: 0, data-max-num-hours: 12, data-min-num-hours: 1]
       num_hours:
         widget: "number_field"
         label: "Maximum duration in hours of your remote session"

--- a/playbooks/ood-overrides-openpbs.yml
+++ b/playbooks/ood-overrides-openpbs.yml
@@ -14,7 +14,7 @@ ood_apps:
     submit: |
       <%-
 
-        node_arrays = {"viz3d" => 24, "viz" => 8, "largeviz3d" => 48}
+        node_arrays = {"viz3d" => 12, "viz" => 8, "largeviz3d" => 48}
 
         scheduler_args = ["-q", "vizq"]
 

--- a/playbooks/ood-overrides-openpbs.yml
+++ b/playbooks/ood-overrides-openpbs.yml
@@ -13,8 +13,7 @@ ood_apps:
   bc_desktop:
     submit: |
       <%-
-
-        node_arrays = {"viz3d" => 12, "viz" => 8, "largeviz3d" => 48}
+        require "yaml"
 
         scheduler_args = ["-q", "vizq"]
 
@@ -27,8 +26,14 @@ ood_apps:
         # If the user has specified a node bucket lower than 100%, set the job ppn
         node_percentage = bucket.to_i
         if node_percentage < 100
-          cores = (node_arrays[target].to_i * node_percentage) / 100
-          scheduler_args += ["-l", "select=1:slot_type=%s:ncpus=%d" % [target, cores]]
+          node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+          node_arrays.each do |slot_type|
+            if slot_type["name"] == target
+              cores = (slot_type["vcpuCount"].to_i * node_percentage) / 100
+              scheduler_args += ["-l", "select=1:slot_type=%s:ncpus=%d" % [target, cores]]
+              break
+            end
+          end
         else
           scheduler_args += ["-l", "select=1:slot_type=%s,place=scatter:excl" % target]
         end

--- a/playbooks/ood-overrides-openpbs.yml
+++ b/playbooks/ood-overrides-openpbs.yml
@@ -13,6 +13,9 @@ ood_apps:
   bc_desktop:
     submit: |
       <%-
+
+        node_arrays = {"viz3d" => 24, "viz" => 8, "largeviz3d" => 48}
+
         scheduler_args = ["-q", "vizq"]
 
         # If the user has specified a number of hours, set the job walltime
@@ -21,9 +24,10 @@ ood_apps:
           scheduler_args += ["-l", "walltime=%02d:00:00" % hours]
         end
 
-        # If the user has specified a number of cores, set the job ppn
-        cores = reservedcores.to_i
-        if cores > 0
+        # If the user has specified a node bucket lower than 100%, set the job ppn
+        node_percentage = bucket.to_i
+        if node_percentage < 100
+          cores = (node_arrays[target].to_i * node_percentage) / 100
           scheduler_args += ["-l", "select=1:slot_type=%s:ncpus=%d" % [target, cores]]
         else
           scheduler_args += ["-l", "select=1:slot_type=%s,place=scatter:excl" % target]

--- a/playbooks/ood-overrides-slurm.yml
+++ b/playbooks/ood-overrides-slurm.yml
@@ -12,6 +12,8 @@ ood_apps:
   bc_desktop:
     submit: |
       <%-
+        node_arrays = {"viz3d" => 24, "viz" => 8, "largeviz3d" => 48}
+
         scheduler_args = ["-p", target]
 
         # If the user has specified a number of hours, set the job walltime
@@ -24,9 +26,10 @@ ood_apps:
           scheduler_args += ["--gpus=1"]
         end
 
-        # If the user has specified a number of cores, set the job ppn
-        cores = reservedcores.to_i
-        if cores > 0
+        # If the user has specified a node bucket lower than 100%, set the job ppn
+        node_percentage = bucket.to_i
+        if node_percentage < 100
+          cores = (node_arrays[target].to_i * node_percentage) / 100
           scheduler_args += ["--ntasks-per-node=%d" % cores]
         else
           scheduler_args += ["--exclusive"]

--- a/playbooks/ood-overrides-slurm.yml
+++ b/playbooks/ood-overrides-slurm.yml
@@ -12,7 +12,7 @@ ood_apps:
   bc_desktop:
     submit: |
       <%-
-        node_arrays = {"viz3d" => 24, "viz" => 8, "largeviz3d" => 48}
+        node_arrays = {"viz3d" => 12, "viz" => 8, "largeviz3d" => 48}
 
         scheduler_args = ["-p", target]
 

--- a/playbooks/ood-overrides-slurm.yml
+++ b/playbooks/ood-overrides-slurm.yml
@@ -12,8 +12,7 @@ ood_apps:
   bc_desktop:
     submit: |
       <%-
-        node_arrays = {"viz3d" => 12, "viz" => 8, "largeviz3d" => 48}
-
+        require "yaml"
         scheduler_args = ["-p", target]
 
         # If the user has specified a number of hours, set the job walltime
@@ -29,8 +28,14 @@ ood_apps:
         # If the user has specified a node bucket lower than 100%, set the job ppn
         node_percentage = bucket.to_i
         if node_percentage < 100
-          cores = (node_arrays[target].to_i * node_percentage) / 100
-          scheduler_args += ["--ntasks-per-node=%d" % cores]
+          node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+          node_arrays.each do |slot_type|
+            if slot_type["name"] == target
+              cores = (slot_type["vcpuCount"].to_i * node_percentage) / 100
+              scheduler_args += ["--ntasks-per-node=%d" % cores]
+              break
+            end
+          end
         else
           scheduler_args += ["--exclusive"]
         end

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -431,3 +431,8 @@
       - name: Configure cvmfs 
         shell: cvmfs_config setup 
     when:  ( cvmfs_eessi.enabled | default(false) )
+
+  # Generate the node array core lookup file for ondemand - will be only run if the marker file for ondemand exists
+  - import_tasks: nodearray_lookup.yml
+    vars:
+      marker_file: cccluster.ok


### PR DESCRIPTION
The Linux Desktop now use dynamic UI widgets to help the end users defining which resources to be used.
- min and max time is now configurable per queue in the configuration file
- Small GPU and Non GPU target are full node only
- node bucket selection to 25%, 50% 100% of a node when using the large viz instance to share sessions

close #1067 