### PR TITLE
Fix secondary DNS for Windows and add influxdb retention policy

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/3-joindomain.bat.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/3-joindomain.bat.j2
@@ -1,6 +1,8 @@
 netsh interface ipv4 set dns name="Ethernet" static {{ primary_dns }}
-netsh interface ipv4 add dns name="Ethernet" static {{ secondary_dns }} index=2
+netsh interface ipv4 add dns name="Ethernet" {{ secondary_dns }} index=2
 netsh interface ipv4 add dns name="Ethernet" 168.63.129.16 index=3
+
+reg add "HKLM\System\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
 
 Powershell.exe -executionpolicy remotesigned try { $password = ConvertTo-SecureString "{{ cc_password | replace("%", "%%")}}" -asPlainText -Force; $credential = New-Object System.Management.Automation.PSCredential('{{ ad_join_domain }}\{{ ad_join_user }}',$password); Add-Computer -DomainName '{{ ad_join_domain }}' -Credential $credential } catch { exit 255 }
 

--- a/playbooks/roles/influxdb/tasks/main.yml
+++ b/playbooks/roles/influxdb/tasks/main.yml
@@ -35,3 +35,14 @@
       password: "{{influxdb_password}}"
       database_name: "{{influxdb_database_name}}"
       validate_certs: no
+
+- name: Change default autogen retention policy - 4 weeks retention policy with 1 day shard group duration
+  community.general.influxdb_retention_policy:
+      username: "{{influxdb_username}}"
+      password: "{{influxdb_password}}"
+      database_name: "{{influxdb_database_name}}"
+      policy_name: "autogen"
+      duration: 4w
+      replication: 1
+      shard_group_duration: 1d
+      default: true


### PR DESCRIPTION
- fix wrong netsh option for secondary DNS
- enable RDP before domain join
- add 4 weeks shard 1 day retention policy for InfluxDB

close #1070 