### PR TITLE
fix: should not need sudo on local machine

### DIFF
--- a/playbooks/nodearray_lookup.yml
+++ b/playbooks/nodearray_lookup.yml
@@ -4,6 +4,7 @@
   register: marker
   delegate_to: localhost
   connection: local
+  become: false
 
 - name: create node array core lookup file for ondemand
   block:


### PR DESCRIPTION
removed sudo in nodearray_lookup.yml when checking if the marker file exists on the local machine