### PR TITLE
remove libnvidia-container-tools

### DIFF
--- a/packer/scripts/almalinux/slurm.sh
+++ b/packer/scripts/almalinux/slurm.sh
@@ -84,12 +84,12 @@ dnf install -y epel-release
 rpm -q enroot || dnf install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 rpm -q enroot+caps || dnf install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 
-# # Install NVIDIA container support
-# #DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
-# curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
+# Install NVIDIA container support
+#DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
 
-# dnf -y makecache
-# dnf -y install libnvidia-container-tools
+dnf -y makecache
+dnf -y install libnvidia-container-tools
 
 # Add kernel boot parameters
 grep user.max_user_namespaces /etc/sysctl.conf || echo 'user.max_user_namespaces = 1417997' >> /etc/sysctl.conf

--- a/packer/scripts/almalinux/slurm.sh
+++ b/packer/scripts/almalinux/slurm.sh
@@ -84,12 +84,12 @@ dnf install -y epel-release
 rpm -q enroot || dnf install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 rpm -q enroot+caps || dnf install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 
-# Install NVIDIA container support
-#DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
+# # Install NVIDIA container support
+# #DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
+# curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
 
-dnf -y makecache
-dnf -y install libnvidia-container-tools
+# dnf -y makecache
+# dnf -y install libnvidia-container-tools
 
 # Add kernel boot parameters
 grep user.max_user_namespaces /etc/sysctl.conf || echo 'user.max_user_namespaces = 1417997' >> /etc/sysctl.conf

--- a/packer/scripts/centos/slurm.sh
+++ b/packer/scripts/centos/slurm.sh
@@ -93,12 +93,12 @@ arch=$(uname -m)
 rpm -q enroot || yum install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 rpm -q enroot+caps || yum install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps-${ENROOT_VERSION_FULL}.el7.${arch}.rpm
 
-# Install NVIDIA container support
-DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/libnvidia-container/$DIST/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
+# # Install NVIDIA container support
+# DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
+# curl -s -L https://nvidia.github.io/libnvidia-container/$DIST/libnvidia-container.repo > /etc/yum.repos.d/libnvidia-container.repo
 
-yum -y makecache
-yum -y install libnvidia-container-tools
+# yum -y makecache
+# yum -y install libnvidia-container-tools
 
 # Add kernel boot parameters
 grep user.max_user_namespaces /etc/sysctl.conf || echo 'user.max_user_namespaces = 1417997' >> /etc/sysctl.conf

--- a/packer/scripts/ubuntu/slurm.sh
+++ b/packer/scripts/ubuntu/slurm.sh
@@ -77,14 +77,14 @@ curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.0/enroot_3
 curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.0/enroot+caps_3.4.0-1_${arch}.deb # optional
 apt install -y ./*.deb
 
-# Install NVIDIA container support
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-         && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-         && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-               sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-               sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-apt-get update
-sudo apt install -y curl gawk jq squashfs-tools parallel
-sudo apt install -y libnvidia-container-tools pigz squashfuse # optional
+# # Install NVIDIA container support
+# distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+#          && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+#          && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+#                sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+#                sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+# apt-get update
+# sudo apt install -y curl gawk jq squashfs-tools parallel
+# sudo apt install -y libnvidia-container-tools pigz squashfuse # optional
 
 enroot version


### PR DESCRIPTION
libnvidia-container-tools are already installed in the Centos and Ubuntu HPC images - removed form packer.
install only on Alma