### PR TITLE
new vglrun alias to pickup a GPU device based on noVNC port number

### DIFF
--- a/packer/scripts/centos/interactive-desktop-3d.sh
+++ b/packer/scripts/centos/interactive-desktop-3d.sh
@@ -83,8 +83,8 @@ chmod +x /etc/rc.d/rc3.d/busidupdate.sh
 cat <<EOF >/etc/profile.d/vglrun.sh 
 #!/bin/bash
 # Set the vglrun alias to pickup a GPU device based on the noVNC port so that each session is landing on a different GPU, modulo the number of GPU devices.
-ngpu=$(lspci | grep NVIDIA | wc -l)
-alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} % ${ngpu:-1}))'
+ngpu=\$(lspci | grep NVIDIA | wc -l)
+alias vglrun='/usr/bin/vglrun -d :0.\$(( \${port:-0} % \${ngpu:-1}))'
 EOF
 
 # browser and codecs

--- a/packer/scripts/centos/interactive-desktop-3d.sh
+++ b/packer/scripts/centos/interactive-desktop-3d.sh
@@ -79,6 +79,14 @@ EOF
 chmod +x /etc/rc.d/rc3.d/busidupdate.sh
 /etc/rc.d/rc3.d/busidupdate.sh
 
+# Create a vglrun alias
+cat <<EOF >/etc/profile.d/vglrun.sh 
+#!/bin/bash
+# Set the vglrun alias to pickup a GPU device based on the noVNC port so that each session is landing on a different GPU, modulo the number of GPU devices.
+ngpu=$(lspci | grep NVIDIA | wc -l)
+alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} % ${ngpu:-1}))'
+EOF
+
 # browser and codecs
 yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
 yum -y install firefox ffmpeg ffmpeg-devel

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -24,7 +24,6 @@ clusters:
             module purge
             export PATH="/opt/TurboVNC/bin:$PATH"
             export WEBSOCKIFY_CMD="/usr/bin/websockify"
-            alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} %% $(lspci | grep NVIDIA | wc -l)))'
             %s
 
 ood_install_apps:

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -24,7 +24,7 @@ clusters:
             module purge
             export PATH="/opt/TurboVNC/bin:$PATH"
             export WEBSOCKIFY_CMD="/usr/bin/websockify"
-            alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} % $(lspci | grep NVIDIA | wc -l)))'
+            alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} %% $(lspci | grep NVIDIA | wc -l)))'
             %s
 
 ood_install_apps:

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -24,6 +24,7 @@ clusters:
             module purge
             export PATH="/opt/TurboVNC/bin:$PATH"
             export WEBSOCKIFY_CMD="/usr/bin/websockify"
+            alias vglrun='/usr/bin/vglrun -d :0.$(( ${port:-0} % $(lspci | grep NVIDIA | wc -l)))'
             %s
 
 ood_install_apps:


### PR DESCRIPTION
create a alias for vglrun to specify the gpu device to use based on the noVNC port number, so that the same node can be fair share by several users.

close #859 