### PR TITLE
removed job_submit plugin from compute node images

### DIFF
--- a/packer/scripts/almalinux/slurm.sh
+++ b/packer/scripts/almalinux/slurm.sh
@@ -54,16 +54,11 @@ export PATH=$PATH:$BUILD_DIR/bin
 wget "${DOWNLOAD_URL}/${SLURM_PKG}"
 rpmbuild --define "_with_pmix --with-pmix=/opt/pmix/v3" -ta ${SLURM_PKG}
 
-# Download the job submit plugin
-wget https://github.com/Azure/cyclecloud-slurm/releases/download/2.6.2/job_submit_cyclecloud_centos_20.11.7-1.so
-
 #
-# Install SLURM and plugin
+# Install SLURM
 #
 
 dnf -y install /root/rpmbuild/RPMS/x86_64/slurm-${SLURM_VERSION}*.rpm /root/rpmbuild/RPMS/x86_64/slurm-slurmd-${SLURM_VERSION}*.rpm
-cp job_submit_cyclecloud_centos_20.11.7-1.so /usr/lib64/slurm/job_submit_cyclecloud.so
-chmod +x /usr/lib64/slurm/job_submit_cyclecloud.so
 
 #
 # The below is needed to CycleCloud chef recipe

--- a/packer/scripts/centos/slurm.sh
+++ b/packer/scripts/centos/slurm.sh
@@ -63,16 +63,11 @@ export PATH=$PATH:$BUILD_DIR/bin
 wget "${DOWNLOAD_URL}/${SLURM_PKG}"
 rpmbuild --define "_with_pmix --with-pmix=/opt/pmix/v3" -ta ${SLURM_PKG}
 
-# Download the job submit plugin
-wget https://github.com/Azure/cyclecloud-slurm/releases/download/2.6.2/job_submit_cyclecloud_centos_20.11.7-1.so
-
 #
-# Install SLURM and plugin
+# Install SLURM
 #
 
 yum -y install /root/rpmbuild/RPMS/x86_64/slurm-${SLURM_VERSION}*.rpm /root/rpmbuild/RPMS/x86_64/slurm-slurmd-${SLURM_VERSION}*.rpm
-cp job_submit_cyclecloud_centos_20.11.7-1.so /usr/lib64/slurm/job_submit_cyclecloud.so
-chmod +x /usr/lib64/slurm/job_submit_cyclecloud.so
 
 #
 # The below is needed to CycleCloud chef recipe

--- a/packer/scripts/ubuntu/slurm.sh
+++ b/packer/scripts/ubuntu/slurm.sh
@@ -50,11 +50,6 @@ make -j install
 # Create slurmd service
 cp etc/slurmd.service /usr/lib/systemd/system/
 
-# Download the job submit plugin
-wget https://github.com/Azure/cyclecloud-slurm/releases/download/2.6.2/job_submit_cyclecloud_ubuntu_20.11.7-1.so
-cp job_submit_cyclecloud_ubuntu_20.11.7-1.so /usr/lib64/slurm/job_submit_cyclecloud.so
-chmod +x /usr/lib64/slurm/job_submit_cyclecloud.so
-
 #
 # The below is needed to CycleCloud chef recipe to work correctly
 #


### PR DESCRIPTION
job submit plugin only needed on the scheduler node (related to #1101)
removed it from images