### PR TITLE
Linux Remote Desktop : Allow 1, 1/2, 1/4, 1/8 node buckets

### DIFF
--- a/.github/workflows/configs/integration.yml
+++ b/.github/workflows/configs/integration.yml
@@ -229,12 +229,16 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
   - name: viz
     vm_size: Standard_D8s_v5
     max_core_count: 200
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
   - name: nc24v3
     vm_size: Standard_NC24rs_v3
     max_core_count: 96
@@ -245,6 +249,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
 
 # Remote Visualization definitions
 enable_remote_winviz: true # Set to true to enable windows remote visualization

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -339,6 +339,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
     # Queue dedicated to share GPU remote viz nodes. This name is fixed and can't be changed
   - name: largeviz3d
     vm_size: Standard_NV48s_v3
@@ -346,6 +348,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12
+    min_hours: 1
     # Queue dedicated to non GPU remote viz nodes. This name is fixed and can't be changed
   - name: viz
     vm_size: Standard_D8s_v5
@@ -353,6 +357,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12
+    min_hours: 1
 
 # Remote Visualization definitions
 enable_remote_winviz: false # Set to true to enable windows remote visualization

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -339,6 +339,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
     # Queue dedicated to share GPU remote viz nodes. This name is fixed and can't be changed
   - name: largeviz3d
     vm_size: Standard_NV48s_v3
@@ -346,6 +348,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
     # Queue dedicated to non GPU remote viz nodes. This name is fixed and can't be changed
   - name: viz
     vm_size: Standard_D8s_v5
@@ -353,6 +357,8 @@ queues:
     image: /subscriptions/{{subscription_id}}/resourceGroups/{{resource_group}}/providers/Microsoft.Compute/galleries/{{sig_name}}/images/azhop-centos79-desktop3d/latest
     ColocateNodes: false
     spot: false
+    max_hours: 12 # Maximum session duration
+    min_hours: 1 # Minimum session duration - 0 is infinite
 
 # Remote Visualization definitions
 enable_remote_winviz: false # Set to true to enable windows remote visualization

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -59,13 +59,13 @@ ood_apps:
           - **Without GPU** <br>
             Same as for **With GPU** but without a GPU accelerator.
         options:
-         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-bucket: true, data-set-bucket: 100, 
+         - ["With GPU - Small GPU node for single session", "viz3d", data-hide-bucket: true, data-set-bucket: 1, 
               data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz3d') | map(attribute='max_hours')) | default(8, true) }}", 
               data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz3d') | map(attribute='min_hours')) | default(1, true) }}"]
          - ["Large With GPU - Intented for shared sessions", "largeviz3d", 
               data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'largeviz3d') | map(attribute='max_hours')) | default(8, true) }}", 
               data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'largeviz3d') | map(attribute='min_hours')) | default(1, true) }}"]
-         - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 100, 
+         - ["Without GPU - for single session", "viz", data-hide-bucket: true, data-set-bucket: 1, 
               data-max-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='max_hours')) | default(8, true) }}", 
               data-min-num-hours: "{{ (queues | selectattr('name', 'equalto', 'viz') | map(attribute='min_hours')) | default(1, true) }}"]
       num_hours:
@@ -81,9 +81,10 @@ ood_apps:
         help: |
           Select how much of the node you want to use <br>
         options:
-         - [" 25 % of the node", "25"]
-         - [" 50 % of the node", "50"]
-         - ["100 % of the node", "100"]
+         - [" 1/8 of the node", "8"]
+         - [" 1/4 of the node", "4"]
+         - [" 1/2 of the node", "2"]
+         - [" the full node", "1"]
 
 host_regex: '[^./]+'
 node_uri: '/node'

--- a/playbooks/ood-overrides-openpbs.yml
+++ b/playbooks/ood-overrides-openpbs.yml
@@ -23,13 +23,13 @@ ood_apps:
           scheduler_args += ["-l", "walltime=%02d:00:00" % hours]
         end
 
-        # If the user has specified a node bucket lower than 100%, set the job ppn
-        node_percentage = bucket.to_i
-        if node_percentage < 100
+        # If the user has specified a node ratio greather than 1, set the job ppn
+        node_ratio = bucket.to_i
+        if node_ratio > 1
           node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
           node_arrays.each do |slot_type|
             if slot_type["name"] == target
-              cores = (slot_type["vcpuCount"].to_i * node_percentage) / 100
+              cores = (slot_type["vcpuCount"].to_i / node_ratio)
               scheduler_args += ["-l", "select=1:slot_type=%s:ncpus=%d" % [target, cores]]
               break
             end

--- a/playbooks/ood-overrides-slurm.yml
+++ b/playbooks/ood-overrides-slurm.yml
@@ -25,13 +25,13 @@ ood_apps:
           scheduler_args += ["--gpus=1"]
         end
 
-        # If the user has specified a node bucket lower than 100%, set the job ppn
-        node_percentage = bucket.to_i
-        if node_percentage < 100
+        # If the user has specified a node ratio greather than 1, set the job ppn
+        node_ratio = bucket.to_i
+        if node_ratio > 1
           node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
           node_arrays.each do |slot_type|
             if slot_type["name"] == target
-              cores = (slot_type["vcpuCount"].to_i * node_percentage) / 100
+              cores = (slot_type["vcpuCount"].to_i / node_ratio)
               scheduler_args += ["--ntasks-per-node=%d" % cores]
               break
             end


### PR DESCRIPTION
- allow users to select from full node to 1/8 of a node
- set default min and max hours for all remote viz queues
