### PR TITLE
added SLURM Grafana dashboard

### DIFF
--- a/playbooks/roles/grafana/dashboards/slurm-stats.json
+++ b/playbooks/roles/grafana/dashboards/slurm-stats.json
@@ -598,9 +598,8 @@
     },
     "timepicker": {},
     "timezone": "",
-    "title": "SLURM statistics",
+    "title": "SLURM Statistics",
     "uid": "M6LFI9V4z",
     "version": 5,
     "weekStart": ""
   }
-  

--- a/playbooks/roles/grafana/dashboards/slurm-stats.json
+++ b/playbooks/roles/grafana/dashboards/slurm-stats.json
@@ -1,0 +1,606 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 8,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P37B1EAF5C6A7BE1B"
+        },
+        "description": "Compute node VMs",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "alias": "$tag_partition",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "partition"
+                ],
+                "type": "tag"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "slurm_nodes",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "B",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "nodes"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "!=",
+                "value": "idle~"
+              }
+            ]
+          }
+        ],
+        "title": "Running VMs",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P37B1EAF5C6A7BE1B"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "axisSoftMin": 0,
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "alias": "$tag_partition $tag_state",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "state"
+                ],
+                "type": "tag"
+              },
+              {
+                "params": [
+                  "partition"
+                ],
+                "type": "tag"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "measurement": "slurm_nodes",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "nodes"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "!=",
+                "value": "idle~"
+              }
+            ]
+          }
+        ],
+        "title": "Compute Node States",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P37B1EAF5C6A7BE1B"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "alias": "Running",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "measurement": "slurm_jobs",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "jobs"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "=",
+                "value": "RUNNING"
+              }
+            ]
+          },
+          {
+            "alias": "Pending",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "slurm_jobs",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "B",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "jobs"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "=",
+                "value": "PENDING"
+              }
+            ]
+          },
+          {
+            "alias": "Configuring",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "slurm_jobs",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "C",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "jobs"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "=",
+                "value": "CONFIGURING"
+              }
+            ]
+          },
+          {
+            "alias": "Other",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "P37B1EAF5C6A7BE1B"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "slurm_jobs",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "refId": "D",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "jobs"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "state",
+                "operator": "=",
+                "value": "OTHER"
+              }
+            ]
+          }
+        ],
+        "title": "SLURM Jobs",
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "SLURM statistics",
+    "uid": "M6LFI9V4z",
+    "version": 5,
+    "weekStart": ""
+  }
+  

--- a/playbooks/telegraf.yml
+++ b/playbooks/telegraf.yml
@@ -157,6 +157,76 @@
               signal = "STDIN"
     when: (queue_manager == "openpbs" or queue_manager is not defined)
 
+- name: SLURM metrics
+  hosts: scheduler
+  become: true
+  vars_files:
+    - '{{global_config_file}}'
+  
+  tasks:
+  - name: create telegraf plugin directory
+    file:
+      path: /opt/telegraf/scripts
+      state: directory
+      mode: 0755
+      owner: telegraf
+
+  - name: add SLURM scripts
+    block:
+      - name: create collect_slurm_stats script
+        copy:
+          dest: /opt/telegraf/scripts/collect_slurm_stats.py
+          mode: 0755
+          owner: telegraf
+          content: |
+            #!/usr/bin/env python
+
+            import json
+            import subprocess
+            import sys
+
+            def sinfo():
+                for sinfo_line in subprocess.check_output(["/bin/sinfo", "-h", "-o", "%R %D %F %T"]).split('\n'):
+                    data = sinfo_line.split(' ')
+                    if (data[0] != ''):
+                        partition = data[0]
+                        numnodes = data[1]
+                        nodes_by_state = data[2].split('/')
+                        state = data[3]
+                        print("slurm_nodes,partition="+partition+",state="+state+" nodes="+numnodes+"i")
+
+            def squeue():
+                jobs_running = 0
+                jobs_pending = 0
+                jobs_other = 0
+                for sinfo_line in subprocess.check_output(["/bin/squeue", "-h", "-o", "%a %D %T"]).split('\n'):
+                    data = sinfo_line.split(' ')
+                    if (data[0] != ''):
+                        account = data[0]
+                        numnodes = data[1]
+                        state = data[2]
+                        # print("slurm2jobs,account="+account+",state="+state+" nodes="+numnodes+"i")
+                        if state == 'RUNNING':
+                            jobs_running += 1
+                        elif state == 'PENDING':
+                            jobs_pending += 1
+                        else:
+                            jobs_other += 1
+                print("slurm_jobs,state=RUNNING jobs="+str(jobs_running)+"i")
+                print("slurm_jobs,state=PENDING jobs="+str(jobs_pending)+"i")
+                print("slurm_jobs,state=OTHER jobs="+str(jobs_other)+"i")
+
+            sinfo()
+            squeue()
+      - name: add slurm metrics to telegraf config
+        blockinfile:
+          path: /etc/telegraf/telegraf.conf
+          block: |
+            [[inputs.execd]]
+              command = ["/opt/telegraf/scripts/collect_slurm_stats.py"]
+              signal = "STDIN"
+    when: (queue_manager == "slurm")
+
   - name: restart telegraf
     service:
       name: telegraf

--- a/playbooks/telegraf.yml
+++ b/playbooks/telegraf.yml
@@ -198,6 +198,7 @@
             def squeue():
                 jobs_running = 0
                 jobs_pending = 0
+                jobs_configuring = 0
                 jobs_other = 0
                 for sinfo_line in subprocess.check_output(["/bin/squeue", "-h", "-o", "%a %D %T"]).split('\n'):
                     data = sinfo_line.split(' ')
@@ -210,10 +211,13 @@
                             jobs_running += 1
                         elif state == 'PENDING':
                             jobs_pending += 1
+                        elif state == 'CONFIGURING':
+                            jobs_configuring += 1
                         else:
                             jobs_other += 1
                 print("slurm_jobs,state=RUNNING jobs="+str(jobs_running)+"i")
                 print("slurm_jobs,state=PENDING jobs="+str(jobs_pending)+"i")
+                print("slurm_jobs,state=CONFIGURING jobs="+str(jobs_configuring)+"i")
                 print("slurm_jobs,state=OTHER jobs="+str(jobs_other)+"i")
 
             sinfo()


### PR DESCRIPTION
SLURM Statistics dashboard for Grafana with collection script. The dashboard contains 3 panels:
- Running VMs by partition
- Compute node by state/partition
- Jobs by state
