### PR TITLE
New parameter to configure the max scaleset size per queue

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -330,6 +330,9 @@ queues:
     ColocateNodes: false
     # Specific idle time in seconds before shutting down VMs, make sure it's lower than autoscale.idle_timeout
     idle_timeout: 300
+    # Set the max number of vm's in a VMSS; requires additional limit raise through support ticket for >100; 
+    # 100 is default value; lower numbers will improve scaling for single node jobs or jobs with small number of nodes
+    MaxScalesetSize: 100
   - name: hc44rs
     vm_size: Standard_HC44rs
     max_core_count: 440

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -332,7 +332,7 @@ queues:
     idle_timeout: 300
     # Set the max number of vm's in a VMSS; requires additional limit raise through support ticket for >100; 
     # 100 is default value; lower numbers will improve scaling for single node jobs or jobs with small number of nodes
-    MaxScalesetSize: 100
+    MaxScaleSetSize: 100
   - name: hc44rs
     vm_size: Standard_HC44rs
     max_core_count: 440

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -328,6 +328,9 @@ queues:
     spot: false
     # Set to false to disable creation of placement groups (for SLURM only). Default is true
     ColocateNodes: false
+    # Set the max number of vm's in a VMSS; requires additional limit raise through support ticket for >100; 
+    # 100 is default value; lower numbers will improve scaling for single node jobs or jobs with small number of nodes
+    MaxScalesetSize: 100
   - name: hc44rs
     vm_size: Standard_HC44rs
     max_core_count: 440

--- a/docs/deploy/define_environment.md
+++ b/docs/deploy/define_environment.md
@@ -330,7 +330,7 @@ queues:
     ColocateNodes: false
     # Set the max number of vm's in a VMSS; requires additional limit raise through support ticket for >100; 
     # 100 is default value; lower numbers will improve scaling for single node jobs or jobs with small number of nodes
-    MaxScalesetSize: 100
+    MaxScaleSetSize: 100
   - name: hc44rs
     vm_size: Standard_HC44rs
     max_core_count: 440

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
@@ -58,6 +58,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
+    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
@@ -58,7 +58,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
-    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
+    Azure.MaxScaleSetSize = {{ queue.MaxScaleSetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-remoteviz.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-remoteviz.txt.j2
@@ -51,7 +51,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
-    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
+    Azure.MaxScaleSetSize = {{ queue.MaxScaleSetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-remoteviz.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-remoteviz.txt.j2
@@ -51,6 +51,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
+    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -91,6 +91,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
+    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -91,7 +91,7 @@ Autoscale = true
   {% if queue.spot is defined %}
     Interruptible = {{queue.spot}}
   {% endif %}
-    Azure.MaxScalesetSize = {{ queue.MaxScalesetSize | default(100) }}
+    Azure.MaxScaleSetSize = {{ queue.MaxScaleSetSize | default(100) }}
     # Lookup image version for that queue
   {% if cc_image_lookup is iterable and queue.name in cc_image_lookup %}
     ImageName = {{ cc_image_lookup[queue.name] }}


### PR DESCRIPTION
default VMSS size is 100. For larger values raise a support ticket. lower values can improve the scaling of single node or few nodes jobs.