### PR TITLE
no pub ip self-signed cert fails

### DIFF
--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -153,7 +153,7 @@
         connection: local
         become: false
         shell: |
-          openssl req -nodes -new -x509 -keyout {{ ondemand_fqdn }}.key -out {{ ondemand_fqdn }}.crt -subj "/CN="
+          openssl req -nodes -new -x509 -keyout {{ ondemand_fqdn }}.key -out {{ ondemand_fqdn }}.crt -subj "/CN={{ ondemand_fqdn }}"
         args:
           creates: "{{ ondemand_fqdn }}.crt"
 


### PR DESCRIPTION
the self-signed cert command fails in no public IP env.  The command run manually on the VM fails with  empty`/CN=` on CentOS.  I manually modified the file to  `/CN={{ ondemand_fqdn }}` and it worked.  

NOTE:  the command with empty `/CN=` does work on Ubuntu 20.04.