### PR TITLE
update OpenOnDemand version to 2.0.29

### DIFF
--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -9,8 +9,8 @@
   vars_files:
     - '{{global_config_file}}'
   vars:
-    ondemand_version: 2.0.28
-    ood_core_version: 0.21.0
+    ondemand_version: 2.0.29
+    ood_core_version: 0.22.0
 
   tasks:
   - name: Wait 300 seconds for the nodes to be ready


### PR DESCRIPTION
- Upgrade OOD to 2.0.29
- Upgrade azhop oodcore to 0.22.0
- fix job list with empty user name when user contains a '.'

close #1204 
close #936 