### PR TITLE
fix alma 8.5 version to 8.5.20211210

### DIFF
--- a/packer/azhop-almalinux85-v2-rdma-gpgpu.json
+++ b/packer/azhop-almalinux85-v2-rdma-gpgpu.json
@@ -6,7 +6,7 @@
             "image_publisher": "almalinux",
             "image_offer": "almalinux-hpc",
             "image_sku": "8_5-hpc-gen2",
-            "image_version": "latest",
+            "image_version": "8.5.20211210",
             "plan_info": {
                 "plan_name": "8_5-hpc-gen2",
                 "plan_publisher": "almalinux",


### PR DESCRIPTION
Fix an issue with the marketplace image of Alma Linux which leads to unintended installation of version 8.6 instead of 8.5.
Fixes #1231
