### PR TITLE
no need to be root to retrieve the azhop version with git

### DIFF
--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -425,6 +425,7 @@
   - name: retrieve azhop version
     delegate_to: localhost
     connection: local
+    become: false
     shell: |
       git describe --always --tags
     register: azhop_version


### PR DESCRIPTION
this fix an issue when root is password protected