### PR TITLE
Update rpc service dependencies

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -29,7 +29,7 @@ mounts:
     mountpoint: /anfhome # /sharedhome for example
     server: '{{anf_home_ip}}' # Specify an existing NFS server name or IP, when using the ANF built in use '{{anf_home_ip}}'
     export: '{{anf_home_path}}' # Specify an existing NFS export directory, when using the ANF built in use '{{anf_home_path}}'
-    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp" # Specify the mount options. Default to rw,hard,rsize=262144,wsize=262144,vers=3,tcp
+    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev" # Specify the mount options. Default to rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev
 #  mount1:
 #    mountpoint: /mount1 
 #    server: a.b.c.d # Specify an existing NFS server name or IP

--- a/deploy/resources/bicep-templates/anf.bicep.j2
+++ b/deploy/resources/bicep-templates/anf.bicep.j2
@@ -75,6 +75,6 @@ output anf_pool_name string = 'anfpool-${resourcePostfix}'
 output anf_volume_name string = 'anfhome'
 output nfs_home_ip string = anfHome.properties.mountTargets[0].ipAddress
 output nfs_home_path string = 'home-${resourcePostfix}'
-output nfs_home_opts string = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp'
+output nfs_home_opts string = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev'
 
 {% endif %}

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -357,7 +357,7 @@ mounts:
     mountpoint: /anfhome # /sharedhome for example
     server: '{{anf_home_ip}}' # Specify an existing NFS server name or IP, when using the ANF built in use '{{anf_home_ip}}'
     export: '{{anf_home_path}}' # Specify an existing NFS export directory, when using the ANF built in use '{{anf_home_path}}'
-    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp" # Specify the mount options. Default to rw,hard,rsize=262144,wsize=262144,vers=3,tcp
+    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev" # Specify the mount options. Default to rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev
 #  mount1:
 #    mountpoint: /mount1 
 #    server: a.b.c.d # Specify an existing NFS server name or IP
@@ -1267,7 +1267,7 @@ mounts:
     mountpoint: <mount point name> # /sharedhome for example
     server: <server name or IP> # Specify an existing NFS server name or IP, when using the ANF built in use '{{anf_home_ip}}'
     export: <export directory> # Specify an existing NFS export directory, when using the ANF built in use '{{anf_home_path}}'
-    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp" # Specify the mount options.
+    options: "rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev" # Specify the mount options.
 ```
 
 ## Use Azure Active Directory for MFA

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/1-mountnfs.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/1-mountnfs.sh.j2
@@ -10,5 +10,5 @@ $script_dir/../files/$os_release/init_mountnfs.sh
 {% for mount in mounts %}
 mkdir {{mounts[mount].mountpoint}}
 echo "mount {{ mounts[mount].server }}:/{{ mounts[mount].export }} {{mounts[mount].mountpoint}}"
-mount -t nfs -o {{ mounts[mount].options | default("rw,hard,rsize=262144,wsize=262144,vers=3,tcp",true) }} {{ mounts[mount].server }}:/{{ mounts[mount].export }} {{mounts[mount].mountpoint}} || exit 1
+mount -t nfs -o {{ mounts[mount].options | default("rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev",true) }} {{ mounts[mount].server }}:/{{ mounts[mount].export }} {{mounts[mount].mountpoint}} || exit 1
 {% endfor %}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -69,7 +69,7 @@ Autoscale = true
         mountpoint = /sched
         export_path = {{mounts.home.export}}/slurm/config
         address = {{mounts.home.server}}
-        options = {{ mounts.home.options | default("rw,hard,rsize=262144,wsize=262144,vers=3,tcp",true) }}
+        options = {{ mounts.home.options | default("rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev",true) }}
 
     [[node nodearraybase]]
     Abstract = true

--- a/playbooks/roles/domain_join/tasks/main.yml
+++ b/playbooks/roles/domain_join/tasks/main.yml
@@ -32,6 +32,19 @@
     state: mounted
     fstype: nfs
 
+# Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1858930
+- name: Update rpc-statd-notify.service
+  replace:
+    path: /usr/lib/systemd/system/rpc-statd-notify.service
+    regexp: 'After=local-fs.target network-online.target nss-lookup.target'
+    replace: 'After=local-fs.target network.target nss-lookup.target'
+
+- name: Update rpc-statd.service
+  replace:
+    path: /usr/lib/systemd/system/rpc-statd.service
+    regexp: 'After=network-online.target nss-lookup.target rpcbind.socket'
+    replace: 'After=network.target nss-lookup.target rpcbind.socket'
+
   # - name: store kerberos password => this is not working
   #   shell: echo "{{domain_password}}" | kinit {{ domain_admin }}@{{ domain_name | upper }}
 

--- a/playbooks/roles/domain_join/tasks/main.yml
+++ b/playbooks/roles/domain_join/tasks/main.yml
@@ -33,17 +33,14 @@
     fstype: nfs
 
 # Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1858930
-- name: Update rpc-statd-notify.service
+- name: Update service dependencies on network-online.target
   replace:
-    path: /usr/lib/systemd/system/rpc-statd-notify.service
-    regexp: 'After=local-fs.target network-online.target nss-lookup.target'
-    replace: 'After=local-fs.target network.target nss-lookup.target'
-
-- name: Update rpc-statd.service
-  replace:
-    path: /usr/lib/systemd/system/rpc-statd.service
-    regexp: 'After=network-online.target nss-lookup.target rpcbind.socket'
-    replace: 'After=network.target nss-lookup.target rpcbind.socket'
+    path: '/usr/lib/systemd/system/{{item}}'
+    regexp: 'network-online.target'
+    replace: 'network.target'
+  with_items:
+    - rpc-statd-notify.service
+    - rpc-statd.service
 
   # - name: store kerberos password => this is not working
   #   shell: echo "{{domain_password}}" | kinit {{ domain_admin }}@{{ domain_name | upper }}

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -47,7 +47,7 @@ resource "local_file" "global_variables" {
       ad2-ip              = local.ad_ha ? azurerm_network_interface.ad2-nic[0].private_ip_address : azurerm_network_interface.ad-nic.private_ip_address
       anf-home-ip         = local.create_anf ? element(azurerm_netapp_volume.home[0].mount_ip_addresses, 0) : local.configuration_yml["mounts"]["home"]["server"]
       anf-home-path       = local.create_anf ? azurerm_netapp_volume.home[0].volume_path : local.configuration_yml["mounts"]["home"]["export"]
-      homedir_options     = try(local.configuration_yml["mounts"]["home"]["options"], "rw,hard,rsize=262144,wsize=262144,vers=3,tcp")
+      homedir_options     = try(local.configuration_yml["mounts"]["home"]["options"], "rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev")
       ondemand-fqdn       = local.allow_public_ip ? azurerm_public_ip.ondemand-pip[0].fqdn : try( local.configuration_yml["ondemand"]["fqdn"], azurerm_network_interface.ondemand-nic.private_ip_address)
       subscription_id     = data.azurerm_subscription.primary.subscription_id
       tenant_id           = data.azurerm_subscription.primary.tenant_id


### PR DESCRIPTION
update dependencies on **network-online** to **network** in services rpc-statd-notify and rpc-statd to avoid NFS mount to hang when triggered by cloud-init scripts on a hard reboot.

close #1251 