### PR TITLE
Revert "grant connect access from the CycleCloud UI to azhop admins"

### DIFF
--- a/playbooks/roles/cyclecloud/files/user_role_record.txt
+++ b/playbooks/roles/cyclecloud/files/user_role_record.txt
@@ -14,4 +14,4 @@ AdType = "Application.Role"
 Description = "AZHOP Cluster Admin"
 GroupRole = false
 Name = "azhop Cluster Admin"
-Allow = {"Clusters/Manage", "Fixed.ClusterMetadata", "Clusters/Administer", "Clusters/Connect"}
+Allow = {"Clusters/Manage", "Fixed.ClusterMetadata"}


### PR DESCRIPTION
Introduce an issue with local home directory created for admin users