### PR TITLE
update telegraf key for rotation

### DIFF
--- a/packer/scripts/almalinux/telegraf.sh
+++ b/packer/scripts/almalinux/telegraf.sh
@@ -8,7 +8,7 @@ name = InfluxDB Repository - RHEL \$releasever
 baseurl = https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
 EOF
 fi
 

--- a/packer/scripts/centos/telegraf.sh
+++ b/packer/scripts/centos/telegraf.sh
@@ -8,7 +8,7 @@ name = InfluxDB Repository - RHEL \$releasever
 baseurl = https://repos.influxdata.com/centos/\$releasever/\$basearch/stable
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
 EOF
 fi
 

--- a/packer/scripts/ubuntu/telegraf.sh
+++ b/packer/scripts/ubuntu/telegraf.sh
@@ -6,7 +6,7 @@ echo " *                                                                        
 echo " ********************************************************************************** "
 
 # Install Telegraf
-wget -qO- https://repos.influxdata.com/influxdb.key | tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
+wget -qO- https://repos.influxdata.com/influxdata-archive_compat.key | tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
 source /etc/os-release
 echo "deb https://repos.influxdata.com/${ID} ${VERSION_CODENAME} stable" | tee /etc/apt/sources.list.d/influxdb.list
 apt-get update

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/almalinux/init_telegraf.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/almalinux/init_telegraf.sh
@@ -7,7 +7,7 @@ name = InfluxDB Repository - RHEL \$releasever
 baseurl = https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
 EOF
 fi
 

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/centos/init_telegraf.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/centos/init_telegraf.sh
@@ -7,7 +7,7 @@ name = InfluxDB Repository - RHEL \$releasever
 baseurl = https://repos.influxdata.com/centos/\$releasever/\$basearch/stable
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
 EOF
 fi
 

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/ubuntu/init_telegraf.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/ubuntu/init_telegraf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if ! dpkg -l telegraf; then
 
-  wget -qO- https://repos.influxdata.com/influxdb.key | tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
+  wget -qO- https://repos.influxdata.com/influxdata-archive_compat.key | tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
   source /etc/os-release
   echo "deb https://repos.influxdata.com/${ID} ${VERSION_CODENAME} stable" | tee /etc/apt/sources.list.d/influxdb.list
   apt-get update 

--- a/playbooks/roles/influxdb/vars/main.yml
+++ b/playbooks/roles/influxdb/vars/main.yml
@@ -1,6 +1,6 @@
 influxdb_repo_stable:
   name: "influxdb-stable"
-  yum_gpg_key: "https://repos.influxdata.com/influxdb.key"
+  yum_gpg_key: "https://repos.influxdata.com/influxdata-archive_compat.key"
   yum_gpg_check: yes
   yum_repo: "https://repos.influxdata.com/centos/$releasever/$basearch/stable"
 

--- a/playbooks/roles/telegraf/vars/main.yml
+++ b/playbooks/roles/telegraf/vars/main.yml
@@ -1,6 +1,6 @@
 influxdb_repo_stable:
   name: "influxdb-stable"
-  yum_gpg_key: "https://repos.influxdata.com/influxdb.key"
+  yum_gpg_key: "https://repos.influxdata.com/influxdata-archive_compat.key"
   yum_gpg_check: yes
   yum_repo: "https://repos.influxdata.com/centos/$releasever/$basearch/stable"
 


### PR DESCRIPTION
The telegraf signing keys were rotated on Jan 26th.

https://www.influxdata.com/blog/linux-package-signing-key-rotation/

We need the new key in order to build packer images