### PR TITLE
set default user for bin/connect

### DIFF
--- a/tf/templates/connect.tmpl
+++ b/tf/templates/connect.tmpl
@@ -7,9 +7,9 @@ elif [[ $1 == "ad" ]]; then
   echo go create tunnel to ad with rdp to localhost:3390
   ssh -i ${admin-user}_id_rsa -fN -L 3390:ad:3389 -p ${jumpbox-ssh-port} ${admin-user}@${jumpbox-pip}
 else
-  exec ssh -i ${admin-user}_id_rsa -o ProxyCommand="ssh -i ${admin-user}_id_rsa -p ${jumpbox-ssh-port} -W %h:%p ${admin-user}@${jumpbox-pip}" "$@"
+  exec ssh -i ${admin-user}_id_rsa -o ProxyCommand="ssh -i ${admin-user}_id_rsa -p ${jumpbox-ssh-port} -W %h:%p ${admin-user}@${jumpbox-pip}" -o "User=${admin-user}" "$@"
 fi
 %{ else }
-  exec ssh -i ${admin-user}_id_rsa "$@"
+  exec ssh -i ${admin-user}_id_rsa  -o "User=${admin-user}" "$@"
 fi
 %{ endif }


### PR DESCRIPTION
This allows `./bin/connect scheduler` instead of
`./bin/connect hpcadmin@scheduler` (but specifying the user explicitly still works).