### PR TITLE
Updates to installer dependency toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ deploy/*params.json
 *parameters.json
 *outputs.json
 *mainTemplate.json
+
+# build dir that may have .git moduless
+toolset/scripts/ansible-build
+

--- a/toolset/scripts/azhop-dependencies.yml
+++ b/toolset/scripts/azhop-dependencies.yml
@@ -20,6 +20,15 @@
     set_fact:
       ansible_distribution: "{{ ansible_distribution | lower }}"
 
+  - name: Create temp build dir
+    file:
+      path: "{{ playbook_dir }}/ansible-build"
+      owner: "{{ ansible_user_id }}"
+      group: "{{ ansible_user_id }}"
+      mode: '0644'
+      state: directory
+    register: build_dir
+
   - block:
 
     - name: "Identify architecture (Ubuntu)"
@@ -82,20 +91,20 @@
     - name: "AzCopy: Download (Ubuntu)"
       get_url:
         url: "http://aka.ms/{{ linux_azcopy_file }}"
-        dest: "/tmp/{{ linux_azcopy_file }}"
+        dest: "{{ build_dir.path }}/{{ linux_azcopy_file }}"
         mode: 0755
 
     - name: "AzCopy: Extract (Ubuntu)"
       # Unable to use the unarchive module to extract the azcopy binary equivalent to below:
-      #command: tar -xvf /tmp/{{ linux_azcopy_file }} --strip-components=1 --wildcards '*/azcopy'
+      #command: tar -xvf {{ build_dir.path }}/{{ linux_azcopy_file }} --strip-components=1 --wildcards '*/azcopy'
       unarchive:
-        src: /tmp/{{ linux_azcopy_file }}
-        dest: /tmp
+        src: "{{ build_dir.path }}/{{ linux_azcopy_file }}"
+        dest: "{{ build_dir.path }}"
         mode: 0755
 
     - name: "AzCopy: Find azcopy (Ubuntu)"
       find:
-        paths: /tmp
+        paths: "{{ build_dir.path }}"
         patterns: "azcopy"
         file_type: file
         recurse: true
@@ -104,7 +113,7 @@
     - name: "AzCopy: Install (Ubuntu)"
       copy:
         src: "{{ azcopy_file_path.files[0].path }}"
-        dest: /usr/local/bin/azcopy
+        dest: /usr/bin/azcopy
         mode: 0755
 
     - name: "Terraform: Download the signing key to a new keyring (Ubuntu)"
@@ -134,7 +143,7 @@
     - name: "yq: Download and install (Ubuntu)"
       get_url:
         url: "https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/{{ yq_binary }}"
-        dest: /usr/local/bin/yq
+        dest: /usr/bin/yq
         mode: 0755
 
     when: ansible_distribution == "ubuntu"
@@ -185,20 +194,20 @@
     - name: "AzCopy: Download (CentOS)"
       get_url:
         url: "http://aka.ms/{{ linux_azcopy_file }}"
-        dest: "/tmp/{{ linux_azcopy_file }}"
+        dest: "{{ build_dir.path }}/{{ linux_azcopy_file }}"
         mode: 0755
 
     - name: "AzCopy: Extract (CentOS)"
       # Unable to use the unarchive module to extract the azcopy binary equivalent to below:
-      #command: tar -xvf /tmp/{{ linux_azcopy_file }} --strip-components=1 --wildcards '*/azcopy'
+      #command: tar -xvf {{ build_dir.path }}/{{ linux_azcopy_file }} --strip-components=1 --wildcards '*/azcopy'
       unarchive:
-        src: "/tmp/{{ linux_azcopy_file }}"
-        dest: /tmp
+        src: "{{ build_dir.path }}/{{ linux_azcopy_file }}"
+        dest: "{{ build_dir.path }}"
         mode: 0755
 
     - name: "AzCopy: Find azcopy (CentOS)"
       find:
-        paths: /tmp
+        paths: "{{ build_dir.path }}"
         patterns: "azcopy"
         file_type: file
         recurse: true
@@ -207,7 +216,7 @@
     - name: "AzCopy: Install (CentOS)"
       copy:
         src: "{{ azcopy_file_path.files[0].path }}"
-        dest: /usr/local/bin/azcopy
+        dest: /usr/bin/azcopy
         mode: 0755
 
     - name: "Terraform: Add Hashicorp repo (CentOS)"
@@ -231,7 +240,7 @@
     - name: "yq: Download and install (CentOS)"
       get_url:
         url: "https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/{{ yq_binary }}"
-        dest: /usr/local/bin/yq
+        dest: /usr/bin/yq
         mode: 0755
 
     when: ansible_distribution == "centos"
@@ -289,7 +298,7 @@
     - name: "AzCopy: Move azcopy (macOS)"
       copy:
         src: "{{ azcopy_file_path.files[0].path }}"
-        dest: /usr/local/bin/azcopy
+        dest: /usr/bin/azcopy
         mode: 0755
 
     - name: "Terraform: Add Hashicorp repo (macOS)"

--- a/toolset/scripts/install.sh
+++ b/toolset/scripts/install.sh
@@ -12,19 +12,19 @@ MINICONDA_INSTALL_SCRIPT="miniconda-installer.sh"
 
 # Always use of virtual environment
 INSTALL_IN_CONDA=true
-# while [[ $# -gt 0 ]]; do
-#     opt="$1"
-#     shift
-#     case "$opt" in
-#         "--conda")
-# 	    INSTALL_IN_CONDA=true
-# 	    shift
-# 	    ;;
-#         "--")
-# 	    break
-# 	    ;;
-#     esac
-# done
+while [[ $# -gt 0 ]]; do
+    opt="$1"
+    shift
+    case "$opt" in
+         "--conda")
+ 	    INSTALL_IN_CONDA=true
+ 	    shift
+ 	    ;;
+         "--")
+ 	    break
+ 	    ;;
+    esac
+done
 
 if [ $INSTALL_IN_CONDA = true ]; then
     os_type=$(uname | awk '{print tolower($0)}')
@@ -46,15 +46,21 @@ if [ $INSTALL_IN_CONDA = true ]; then
         exit 1
     fi
 
-    printf "Installing Ansible in conda environment in %s from %s \n\n" "${MINICONDA_INSTALL_DIR}" "${miniconda_url}"
+    # Reuse environment if it doesn't already exist
+    if [[ ! -d "${MINICONDA_INSTALL_DIR}" ]]; then
+        printf "Installing Ansible in conda environment in %s from %s \n\n" "${MINICONDA_INSTALL_DIR}" "${miniconda_url}"
 
-    # Actually install environment and install in base environment
-    if [[ ! -f ${MINICONDA_INSTALL_SCRIPT} ]]; then
-        wget $miniconda_url -O $MINICONDA_INSTALL_SCRIPT
+        # Actually install environment and install in base environment
+        if [[ ! -f ${MINICONDA_INSTALL_SCRIPT} ]]; then
+            wget $miniconda_url -O $MINICONDA_INSTALL_SCRIPT
+        fi
+        bash $MINICONDA_INSTALL_SCRIPT -b -p $MINICONDA_INSTALL_DIR
+        source "${MINICONDA_INSTALL_DIR}/bin/activate"
+    else
+        printf "Installing Ansible in existing conda environment in %s \n\n"
+        source "${MINICONDA_INSTALL_DIR}/bin/activate"
     fi
-    bash $MINICONDA_INSTALL_SCRIPT -b -p $MINICONDA_INSTALL_DIR
 
-    source "${MINICONDA_INSTALL_DIR}/bin/activate"
 else
     printf "Attempting to install Ansible in base environment\n"
     printf "If this fails, please run this script with the --conda flag\n\n"
@@ -72,37 +78,24 @@ ansible-galaxy collection install -r ${THIS_DIR}/requirements.yml
 printf "Installing Az-hop dependencies\n"
 ansible-playbook ${THIS_DIR}/azhop-dependencies.yml
 
-echo "=============="
-echo "Python version"
-echo "=============="
-python3 --version || exit 1
-echo "==============="
-echo "Ansible version"
-echo "==============="
-ansible --version || exit 1
-echo "================="
-echo "Terraform version"
-echo "================="
-terraform --version || exit 1
-echo "=============="
-echo "Packer version"
-echo "=============="
-packer --version || exit 1
-echo "=========="
-echo "AZ version"
-echo "=========="
-az --version || exit 1
-echo "=========="
-echo "AZ Copy version"
-echo "=========="
-azcopy --version || exit 1
-echo "=========="
-echo "yq version"
-echo "=========="
-yq --version || exit 1
-echo "End"
+printf "\n\n"
+printf "Applications installed\n"
+printf "===============================================================================\n"
+columns="%-15s| %.10s\n"
+printf "$columns" Application Version
+printf -- "-------------------------------------------------------------------------------\n"
+printf "$columns" Python `python3 --version | awk '{ print $2 }'`
+printf "$columns" Ansible `ansible --version | head -n 1 | awk '{ print $3 }' | sed 's/]//'`
+printf "$columns" Terraform `terraform --version | head -n 1 | awk '{ print $2 }' | sed 's/v//'`
+printf "$columns" Packer `packer --version`
+printf "$columns" "az-cli" `az --version 2> /dev/null | head -n 1 | awk '{ print $2 }'`
+printf "$columns" azcopy `azcopy --version | awk '{ print $3 }'`
+printf "$columns" yq `yq --version | awk '{ print $4 }'`
+printf "===============================================================================\n"
 
 if [ $INSTALL_IN_CONDA = true ]; then
-    printf "\nAz-HOP dependencies installed in conda environment. To activate, run:\n"
+    yellow=$'\e[1;33m'
+    default=$'\e[0m'
+    printf "\n${yellow}Az-HOP dependencies installed in a conda environment${default}. To activate, run:\n" $red
     printf "\nsource %s/bin/activate\n\n" "${MINICONDA_INSTALL_DIR}"
 fi

--- a/toolset/scripts/install.sh
+++ b/toolset/scripts/install.sh
@@ -11,21 +11,7 @@ MINICONDA_INSTALL_DIR="miniconda"
 MINICONDA_INSTALL_SCRIPT="miniconda-installer.sh"
 
 # Always use of virtual environment
-INSTALL_IN_CONDA=true
-while [[ $# -gt 0 ]]; do
-    opt="$1"
-    shift
-    case "$opt" in
-         "--conda")
- 	    INSTALL_IN_CONDA=true
- 	    shift
- 	    ;;
-         "--")
- 	    break
- 	    ;;
-    esac
-done
-
+INSTALL_IN_CONDA=${INSTALL_IN_CONDA:-true}
 if [ $INSTALL_IN_CONDA = true ]; then
     os_type=$(uname | awk '{print tolower($0)}')
     os_arch=$(arch)


### PR DESCRIPTION
- Use of build dir in toolchain dir instead to /tmp to avoid permissions issues #1429 
- Change install dir to /usr/bin instead of /usr/local/bin to pass checks in install.sh
- Removed comments on commented code that will not run by default anyway
- Add check to see if conda enviroment already exists
- Improved formatting of installed application version check