### PR TITLE
fix empty alert_email

### DIFF
--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -67,11 +67,11 @@ locals {
     monitor = ( local.create_log_analytics_workspace || local.use_existing_ws ) ? true : false
     ama_install = try(local.configuration_yml["monitoring"]["install_agent"], true) && local.monitor ? true : false
 
-    alert_email = try(local.configuration_yml["alerting"]["admin_email"], null)
+    alert_email = try(local.configuration_yml["alerting"]["admin_email"], "admin.mail@contoso.com")
 
     #For alerting to be enabled - the analytics workspace needs to be created since log alerts are leveraged. 
     #We also need to ensure that we have an email to send alerts to.  
-    create_alerts = local.monitor && local.alert_email != null && local.alert_email != "admin.mail@contoso.com" && try(local.configuration_yml["alerting"]["enabled"], false) ? true : false
+    create_alerts = local.monitor && local.alert_email != "admin.mail@contoso.com" && try(local.configuration_yml["alerting"]["enabled"], false) ? true : false
     anf_vol_threshold = try(local.configuration_yml["anf"]["alert_threshold"], 80)  # default to 80% if not specified 
 
     # will be used with a KQL query that checks the free space percentage of local volumes


### PR DESCRIPTION
fix default value to be used when no email alert is defined in the configuration file

```
│ Error: Missing required argument
│ 
│   with azurerm_monitor_action_group.azhop_action_group,
│   on monitor.tf line 17, in resource "azurerm_monitor_action_group" "azhop_action_group":
│   17:     email_address = local.alert_email
│ 
│ The argument "email_receiver.0.email_address" is required, but no definition was found.

```