### PR TITLE
generic: jsonschema => check-jsonschema

### DIFF
--- a/toolset/scripts/requirements.txt
+++ b/toolset/scripts/requirements.txt
@@ -3,4 +3,4 @@ PySocks
 netaddr
 yamllint
 ansible
-jsonschema
+check-jsonschema

--- a/validate_config.sh
+++ b/validate_config.sh
@@ -10,7 +10,7 @@ function validate_config_yml {
     tmp_json=${config}.json
     yq $config -o json > $tmp_json
     set +e
-    jsonschema --instance $tmp_json $SCHEMA
+    check-jsonschema --schemafile $SCHEMA $tmp_json
     retcode=$?
     set -e
     rm $tmp_json


### PR DESCRIPTION
jsonschema is deprecated; switch to `check-jsonschema`

This also has much nicer error messages:

```
Schema validation errors were encountered.
  config.yml.json::$.key_vault_readers: None is not of type 'string'
  config.yml.json::$.network.vnet.id: None is not of type 'string'
  config.yml.json::$.slurm: Additional properties are not allowed ('enroot_enabled' was unexpected)
  config.yml.json::$.images[2].version: 'latest' is not of type 'number'
```