### PR TITLE
Create AD Domain - remove automatic retries

### DIFF
--- a/playbooks/ad.yml
+++ b/playbooks/ad.yml
@@ -74,8 +74,6 @@
           dns_domain_name: '{{domain_name}}'
           safe_mode_password: '{{ad_join_password.stdout}}'
         register: ad_promotion
-        retries: 3
-        delay: 30
         until: ad_promotion is succeeded
         
       # - name: Promote server


### PR DESCRIPTION
Remove the automatic retry in Ansible when creating the AD Domain as it creates a side effect when trying to connect to the AD VM.

close #1519 