### PR TITLE
Set tracking to resource group scope

### DIFF
--- a/marketplace/solution/tracking_resource.json
+++ b/marketplace/solution/tracking_resource.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "2020-06-01",
   "name": "pid-9dde42e6-8b35-48e9-90b2-e7acb2691dce-partnercenter",
-  "location": "[parameters('location')]",
+  "resourceGroup": "[variables('resource_group_name')]",
   "type": "Microsoft.Resources/deployments",
   "properties": {
     "mode": "Incremental",
@@ -10,5 +10,8 @@
       "contentVersion": "1.0.0.0",
       "resources": []
     }
-  }
+  },
+  "dependsOn": [
+    "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resource_group_name'))]"
+  ]
 }


### PR DESCRIPTION
If it is using the subscription scope it will only deploy in one region