### PR TITLE
Config.yml settings for resource names

### DIFF
--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -117,6 +117,7 @@ var config = {
   }
 
   key_vault_name: contains(azhopConfig, 'key_vault') ? azhopConfig.key_vault.name : 'kv${resourcePostfix}'
+  storage_account_name: contains(azhopConfig, 'storage_account') ? azhopConfig.storage_account.name : 'azhop${resourcePostfix}'
 
   enable_remote_winviz : enableWinViz
   deploy_sig: contains(azhopConfig, 'image_gallery') && contains(azhopConfig.image_gallery, 'create') ? azhopConfig.image_gallery.create : false
@@ -744,7 +745,7 @@ module azhopStorage './storage.bicep' = {
   name: 'azhopStorage'
   params:{
     location: location
-    resourcePostfix: resourcePostfix
+    saName: config.storage_account_name
     lockDownNetwork: config.lock_down_network.enforce
     allowableIps: config.lock_down_network.grant_access_from
     subnetIds: [ subnetIds.admin, subnetIds.compute ]
@@ -852,7 +853,7 @@ var kvSuffix = environment().suffixes.keyvaultDns
 
 output azhopGlobalConfig object = union(
   {
-    global_cc_storage             : 'azhop${resourcePostfix}'
+    global_cc_storage             : config.storage_account_name
     compute_subnetid              : '${azhopResourceGroupName}/${config.vnet.name}/${config.vnet.subnets.compute.name}'
     global_config_file            : '/az-hop/config.yml'
     ad_join_user                  : config.domain.domain_join_user.username
@@ -863,9 +864,9 @@ output azhopGlobalConfig object = union(
     ansible_ssh_private_key_file  : '${config.admin_user}_id_rsa'
     subscription_id               : subscription().subscriptionId
     tenant_id                     : subscription().tenantId
-    key_vault                     : 'kv${resourcePostfix}'
+    key_vault                     : config.key_vault_name
     sig_name                      : (config.deploy_sig) ? 'azhop_${resourcePostfix}' : ''
-    lustre_hsm_storage_account    : 'azhop${resourcePostfix}'
+    lustre_hsm_storage_account    : config.storage_account_name
     lustre_hsm_storage_container  : 'lustre'
     database_fqdn                 : createDatabase ? azhopMariaDB.outputs.mariaDb_fqdn : ''
     database_user                 : config.slurm.admin_user

--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -1015,7 +1015,7 @@ user=$1
 # Because secret names are restricted to '^[0-9a-zA-Z-]+$' we need to remove all other characters
 secret_name=$(echo $user-password | tr -dc 'a-zA-Z0-9-')
 
-az keyvault secret show --vault-name kv{0} -n $secret_name --query "value" -o tsv
+az keyvault secret show --vault-name {0} -n $secret_name --query "value" -o tsv
 
-''', resourcePostfix)
+''', config.key_vault_name)
 

--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -116,8 +116,8 @@ var config = {
     ldap_server: createAD ? 'ad' : azhopConfig.domain.existing_dc_details.domain_controller_names[0]
   }
 
-  key_vault_name: contains(azhopConfig, 'azure_key_vault') ? azhopConfig.key_vault.name : 'kv${resourcePostfix}'
-  storage_account_name: contains(azhopConfig, 'azure_storage_account') ? azhopConfig.storage_account.name : 'azhop${resourcePostfix}'
+  key_vault_name: contains(azhopConfig, 'azure_key_vault') ? azhopConfig.azure_key_vault.name : 'kv${resourcePostfix}'
+  storage_account_name: contains(azhopConfig, 'azure_storage_account') ? azhopConfig.azure_storage_account.name : 'azhop${resourcePostfix}'
 
   enable_remote_winviz : enableWinViz
   deploy_sig: contains(azhopConfig, 'image_gallery') && contains(azhopConfig.image_gallery, 'create') ? azhopConfig.image_gallery.create : false

--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -118,6 +118,7 @@ var config = {
 
   key_vault_name: contains(azhopConfig, 'azure_key_vault') ? azhopConfig.azure_key_vault.name : 'kv${resourcePostfix}'
   storage_account_name: contains(azhopConfig, 'azure_storage_account') ? azhopConfig.azure_storage_account.name : 'azhop${resourcePostfix}'
+  mariadb_name: contains(azhopConfig, 'database') && contains(azhopConfig.database, 'name') ? azhopConfig.database.name : 'azhop-${resourcePostfix}'
 
   enable_remote_winviz : enableWinViz
   deploy_sig: contains(azhopConfig, 'image_gallery') && contains(azhopConfig.image_gallery, 'create') ? azhopConfig.image_gallery.create : false
@@ -764,7 +765,7 @@ module azhopMariaDB './mariadb.bicep' = if (createDatabase) {
   name: 'azhopMariaDB'
   params: {
     location: location
-    resourcePostfix: resourcePostfix
+    mariaDbName: config.mariadb_name
     adminUser: config.slurm.admin_user
     adminPassword: secrets.databaseAdminPassword
     adminSubnetId: subnetIds.admin

--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -116,6 +116,8 @@ var config = {
     ldap_server: createAD ? 'ad' : azhopConfig.domain.existing_dc_details.domain_controller_names[0]
   }
 
+  key_vault_name: contains(azhopConfig, 'key_vault') ? azhopConfig.key_vault.name : 'kv${resourcePostfix}'
+
   enable_remote_winviz : enableWinViz
   deploy_sig: contains(azhopConfig, 'image_gallery') && contains(azhopConfig.image_gallery, 'create') ? azhopConfig.image_gallery.create : false
 
@@ -664,7 +666,7 @@ module azhopKeyvault './keyvault.bicep' = {
   name: 'azhopKeyvault'
   params: {
     location: location
-    resourcePostfix: resourcePostfix
+    kvName: config.key_vault_name
     subnetId: subnetIds.admin
     keyvaultReaderOids: config.keyvault_readers
     lockDownNetwork: config.lock_down_network.enforce

--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -116,8 +116,8 @@ var config = {
     ldap_server: createAD ? 'ad' : azhopConfig.domain.existing_dc_details.domain_controller_names[0]
   }
 
-  key_vault_name: contains(azhopConfig, 'key_vault') ? azhopConfig.key_vault.name : 'kv${resourcePostfix}'
-  storage_account_name: contains(azhopConfig, 'storage_account') ? azhopConfig.storage_account.name : 'azhop${resourcePostfix}'
+  key_vault_name: contains(azhopConfig, 'azure_key_vault') ? azhopConfig.key_vault.name : 'kv${resourcePostfix}'
+  storage_account_name: contains(azhopConfig, 'azure_storage_account') ? azhopConfig.storage_account.name : 'azhop${resourcePostfix}'
 
   enable_remote_winviz : enableWinViz
   deploy_sig: contains(azhopConfig, 'image_gallery') && contains(azhopConfig.image_gallery, 'create') ? azhopConfig.image_gallery.create : false

--- a/bicep/keyvault.bicep
+++ b/bicep/keyvault.bicep
@@ -1,15 +1,13 @@
 targetScope = 'resourceGroup'
 
 param location string
-param resourcePostfix string
+param kvName string
 param subnetId string
 param keyvaultReaderOids array
 param keyvaultOwnerId string
 param lockDownNetwork bool
 param allowableIps array
 param identityPerms array
-
-var kvName = 'kv${resourcePostfix}'
 
 output keyvaultName string = kvName
 

--- a/bicep/mariadb.bicep
+++ b/bicep/mariadb.bicep
@@ -1,7 +1,7 @@
 targetScope = 'resourceGroup'
 
 param location string
-param resourcePostfix string
+param mariaDbName string
 param adminUser string
 @secure()
 param adminPassword string
@@ -11,7 +11,7 @@ param sslEnforcement bool
 param vnetId string
 
 resource mariaDb 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
-  name: 'azhop-${resourcePostfix}'
+  name: mariaDbName
   location: location
   
   sku: {
@@ -36,12 +36,12 @@ resource mariaDb 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
 output mariaDb_fqdn string = reference(mariaDb.id, mariaDb.apiVersion, 'full').properties.fullyQualifiedDomainName
 
 resource mariaDbPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-05-01' = {
-  name: 'mariadb-pe-${resourcePostfix}'
+  name: '${mariaDbName}-pe'
   location: location
   properties: {
     privateLinkServiceConnections: [
       {
-        name: 'mariadb-private-connection-${resourcePostfix}'
+        name: '${mariaDbName}-private-connection'
         properties: {
           privateLinkServiceId: mariaDb.id
           groupIds: [

--- a/bicep/storage.bicep
+++ b/bicep/storage.bicep
@@ -1,13 +1,13 @@
 targetScope = 'resourceGroup'
 
 param location string
-param resourcePostfix string
+param saName string
 param lockDownNetwork bool
 param allowableIps array
 param subnetIds array
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
-  name: 'azhop${resourcePostfix}'
+  name: saName
   location: location
   sku: {
     name: 'Standard_LRS'

--- a/config.schema.json
+++ b/config.schema.json
@@ -579,6 +579,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the database resource to be created"
+                },
                 "user": {
                     "type": "string",
                     "description": "Admin user of the database for which the password will be retrieved from the azhop keyvault"

--- a/config.schema.json
+++ b/config.schema.json
@@ -57,11 +57,11 @@
                     "description": "When working in a locked down network, uncomment and fill out this section",
                     "$ref": "#/definitions/LockedDownNetwork"
                 },
-                "key_vault": {
+                "azure_key_vault": {
                     "description": "Key vault configuration",
                     "$ref": "#/definitions/KeyVault"
                 },
-                "storage_account": {
+                "azure_storage_account": {
                     "description": "Storage account configuration",
                     "$ref": "#/definitions/StorageAccount"
                 },

--- a/config.schema.json
+++ b/config.schema.json
@@ -596,9 +596,6 @@
                     "description": "IP of the managed private endpoint if the FQDN is not registered in a private DNS"
                 }
             },
-            "required": [
-                "user"
-            ],
             "title": "Database"
         },
         "Image": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -57,6 +57,14 @@
                     "description": "When working in a locked down network, uncomment and fill out this section",
                     "$ref": "#/definitions/LockedDownNetwork"
                 },
+                "key_vault": {
+                    "description": "Key vault configuration",
+                    "$ref": "#/definitions/KeyVault"
+                },
+                "storage_account": {
+                    "description": "Storage account configuration",
+                    "$ref": "#/definitions/StorageAccount"
+                },
                 "linux_base_image": {
                     "description": "Can be either an image reference or an image_id from the image registry or a custom managed image",
                     "type": "string"
@@ -736,6 +744,26 @@
                 "public_ip"
             ],
             "title": "LockedDownNetwork"
+        },
+        "KeyVault": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string" 
+                }
+            },
+            "title": "KeyVault"
+        },
+        "StorageAccount": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string" 
+                }
+            },
+            "title": "StorageAccount"
         },
         "Mounts": {
             "type": "object",

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -291,11 +291,14 @@ slurm:
 enroot:
   enroot_version: 3.4.1
 
-# If using an existing Managed MariaDB instance for SLURM accounting and/or Guacamole, specify these values
 #database:
+  # Resource name of the MariaDB instance to be created
+  #name: custom_mariadb_name
+
+  # If using an existing Managed MariaDB instance for SLURM accounting and/or Guacamole, specify these values
   # Admin user of the database for which the password will be retrieved from the azhop keyvault
   #user: sqladmin
-  # FQDN of the managed instance
+  # FQDN of the existing managed instance
   #fqdn:
   # IP of the managed private endpoint if the FQDN is not registered in a private DNS
   #ip:

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -187,9 +187,13 @@ domain:
     domain_controller_ip_addresses: ["192.168.1.100", "192.168.1.101"]
     private_dns_servers: ["192.168.1.53", "192.168.2.53"]
 
-# Optional: name of the Key Vault resource to be created. If not provided, a name will be generated
+# Optional: name of the key vault resource to be created. If not provided, a name will be generated
 # key_vault:
 #   name: custom_key_vault_name
+
+# Optional: name of the storage account to be created.
+# storage_account:
+#   name: custom_storage_account_name
 
 # Jumpbox VM configuration, only needed when deploying thru a public IP and without a configured deployer VM
 jumpbox:

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -188,11 +188,11 @@ domain:
     private_dns_servers: ["192.168.1.53", "192.168.2.53"]
 
 # Optional: name of the key vault resource to be created. If not provided, a name will be generated
-# key_vault:
+# azure_key_vault:
 #   name: custom_key_vault_name
 
 # Optional: name of the storage account to be created.
-# storage_account:
+# azure_storage_account:
 #   name: custom_storage_account_name
 
 # Jumpbox VM configuration, only needed when deploying thru a public IP and without a configured deployer VM

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -187,6 +187,10 @@ domain:
     domain_controller_ip_addresses: ["192.168.1.100", "192.168.1.101"]
     private_dns_servers: ["192.168.1.53", "192.168.2.53"]
 
+# Optional: name of the Key Vault resource to be created. If not provided, a name will be generated
+# key_vault:
+#   name: custom_key_vault_name
+
 # Jumpbox VM configuration, only needed when deploying thru a public IP and without a configured deployer VM
 jumpbox:
   vm_size: Standard_B2ms

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -556,6 +556,14 @@ domain:
     domain_controller_ip_addresses: ["192.168.1.100", "192.168.1.101"]
     private_dns_servers: ["192.168.1.53", "192.168.2.53"]
 
+# Optional: name of the key vault resource to be created. If not provided, a name will be generated
+azure_key_vault:
+  name: custom_key_vault_name
+
+# Optional: name of the storage account to be created. If not provided, a name will be generated
+azure_storage_account:
+  name: custom_storage_account_name
+
 # Jumpbox VM configuration, only needed when deploying thru a public IP and without a configured deployer VM
 jumpbox:
   vm_size: Standard_B2ms
@@ -651,8 +659,11 @@ slurm:
 enroot:
   enroot_version: 3.4.1
 
-# If using an existing Managed MariaDB instance for SLURM accounting and/or Guacamole, specify these values
+# Optional: database settings
 database:
+  # Name of the Azure database resource to be created. If not provided, a name will be generated
+  name: custom_mariadb_name
+  # If using an existing Managed MariaDB instance for SLURM accounting and/or Guacamole, specify these values
   # Admin user of the database for which the password will be retrieved from the azhop keyvault
   user: sqladmin
   # FQDN of the managed instance

--- a/tf/keyvault.tf
+++ b/tf/keyvault.tf
@@ -4,7 +4,7 @@ resource "time_sleep" "delay_create" {
 }
 
 resource "azurerm_key_vault" "azhop" {
-  name                        = format("%s%s", "kv", random_string.resource_postfix.result)
+  name                        = local.key_vault_name
   location                    = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name         = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   enabled_for_disk_encryption = true

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -81,7 +81,7 @@ resource "local_file" "public_key" {
 #   - CycleCloud projects
 #   - Terraform states
 resource "azurerm_storage_account" "azhop" {
-    name                     = "azhop${random_string.resource_postfix.result}"
+    name                     = local.storage_account_name
     resource_group_name      = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
     location                 = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
     account_tier             = "Standard"

--- a/tf/mariadb.tf
+++ b/tf/mariadb.tf
@@ -1,6 +1,6 @@
 resource "azurerm_mariadb_server" "mariadb" {
   count               = local.create_database ? 1 : 0
-  name                = "azhop-${random_string.resource_postfix.result}"
+  name                = local.mariadb_name
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
 
@@ -36,7 +36,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "mariadb_dns_link" {
 
 resource azurerm_private_endpoint "mariadb"  {
   count               = local.create_database ? 1 : 0
-  name                = "mariadb-pe-${random_string.resource_postfix.result}"
+  name                = "${local.mariadb_name}-pe"
   location            = local.create_rg ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   resource_group_name = local.create_rg ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.rg[0].name
   subnet_id           = local.create_admin_subnet ? azurerm_subnet.admin[0].id : data.azurerm_subnet.admin[0].id
@@ -47,7 +47,7 @@ resource azurerm_private_endpoint "mariadb"  {
   }
 
   private_service_connection {
-    name                              = "mariadb-private-connection-${random_string.resource_postfix.result}"
+    name                              = "${local.mariadb_name}-private-connection"
     private_connection_resource_id    = azurerm_mariadb_server.mariadb[0].id
     is_manual_connection              = false
     subresource_names                 = [ "mariadbServer" ]

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -190,6 +190,7 @@ locals {
     key_vault_readers = try(local.configuration_yml["key_vault_readers"], null)
 
     key_vault_name = try(local.configuration_yml["key_vault"]["name"], format("%s%s", "kv", random_string.resource_postfix.result))
+    storage_account_name = try(local.configuration_yml["storage_account"]["name"], "azhop${random_string.resource_postfix.result}")
 
     # Lustre
     lustre_enabled = try(local.configuration_yml["lustre"]["create"], false)

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -189,8 +189,8 @@ locals {
     admin_username = local.configuration_yml["admin_user"]
     key_vault_readers = try(local.configuration_yml["key_vault_readers"], null)
 
-    key_vault_name = try(local.configuration_yml["key_vault"]["name"], format("%s%s", "kv", random_string.resource_postfix.result))
-    storage_account_name = try(local.configuration_yml["storage_account"]["name"], "azhop${random_string.resource_postfix.result}")
+    key_vault_name = try(local.configuration_yml["azure_key_vault"]["name"], format("%s%s", "kv", random_string.resource_postfix.result))
+    storage_account_name = try(local.configuration_yml["azure_storage_account"]["name"], "azhop${random_string.resource_postfix.result}")
 
     # Lustre
     lustre_enabled = try(local.configuration_yml["lustre"]["create"], false)

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -191,6 +191,7 @@ locals {
 
     key_vault_name = try(local.configuration_yml["azure_key_vault"]["name"], format("%s%s", "kv", random_string.resource_postfix.result))
     storage_account_name = try(local.configuration_yml["azure_storage_account"]["name"], "azhop${random_string.resource_postfix.result}")
+    mariadb_name = try(local.configuration_yml["database"]["name"], "azhop-${random_string.resource_postfix.result}")
 
     # Lustre
     lustre_enabled = try(local.configuration_yml["lustre"]["create"], false)

--- a/tf/variables_local.tf
+++ b/tf/variables_local.tf
@@ -189,6 +189,8 @@ locals {
     admin_username = local.configuration_yml["admin_user"]
     key_vault_readers = try(local.configuration_yml["key_vault_readers"], null)
 
+    key_vault_name = try(local.configuration_yml["key_vault"]["name"], format("%s%s", "kv", random_string.resource_postfix.result))
+
     # Lustre
     lustre_enabled = try(local.configuration_yml["lustre"]["create"], false)
     lustre_archive_account = try(local.configuration_yml["lustre"]["hsm"]["storage_account"], null)


### PR DESCRIPTION
New settings in config.yml to specify custom resource names for Key Vault, Storage Account and MariaDB:

azure_key_vault:
  name: custom_kv_name
azure_storage_account:
  name: custom_sa_name
database:
  name: custom db name (when datatase is to be created)