### PR TITLE
Initialize OOD application when needed

### DIFF
--- a/playbooks/roles/ood-applications/defaults/main.yml
+++ b/playbooks/roles/ood-applications/defaults/main.yml
@@ -2,9 +2,9 @@ ood_base_apache_dir: "/var/www/ood"
 ood_app_dir: "{{ ood_base_apache_dir }}/apps"
 ood_sys_app_dir: "{{ ood_app_dir }}/sys"
 ood_azhop_apps:
-    - { name: "cyclecloud", enabled: true }
-    - { name: "grafana", enabled: true }
-    - { name: "robinhood", enabled: '{{true if ( lustre.create | default(false) ) else false}}' }
+    - { name: "cyclecloud", enabled: true, initialized: true }
+    - { name: "grafana", enabled: true, initialized: true }
+    - { name: "robinhood", enabled: '{{true if ( lustre.create | default(false) ) else false}}', initialized: true }
     - { name: "bc_guacamole", enabled: '{{enable_remote_winviz | default(false)}}' }
     - { name: "bc_codeserver", enabled: '{{applications.bc_codeserver.enabled | default(true)}}' }
     - { name: "bc_jupyter", enabled: '{{ applications.bc_jupyter.enabled | default(true)}}' }

--- a/playbooks/roles/ood-applications/tasks/main.yml
+++ b/playbooks/roles/ood-applications/tasks/main.yml
@@ -20,6 +20,17 @@
   when: item.enabled
   loop: '{{ood_azhop_apps}}'
 
+- name: Initialize application
+  file:
+    path: /var/lib/ondemand-nginx/config/apps/sys/{{ item.name }}.conf
+    state: touch
+  when: item.enabled and (item.initialized | default(false))
+  loop: '{{ood_azhop_apps}}'
+
+- name: update nginx stage
+  shell: |
+      /opt/ood/nginx_stage/sbin/update_nginx_stage &>/dev/null || :
+
 - name: Install ParaView files
   include_tasks: paraview.yml
   tags: [ 'paraview' ]


### PR DESCRIPTION
This is to avoid the "Initialize App" red button after a new deployment

close #1284 