### PR TITLE
fix ansible version to be 7.6.0

### DIFF
--- a/toolset/scripts/requirements.txt
+++ b/toolset/scripts/requirements.txt
@@ -2,5 +2,5 @@ pypsrp
 PySocks
 netaddr
 yamllint
-ansible
+ansible==7.6.0
 check-jsonschema


### PR DESCRIPTION
Latest version of Ansible 8.0.0 introduce a regression on the AD playbook. Force the version of Ansible to be 7.6.0 to mitigate that regression.

close #1588 