### PR TITLE
don't automatically upgrade grafana

### DIFF
--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -80,4 +80,4 @@
     yum:
       name: '*'
       state: latest
-#      exclude: kernel*,kmod*,amlfs*
+      exclude: grafana*


### PR DESCRIPTION
Grafana was automatically upgraded from 9.x to 10.0 which was failing to start. This was due to the yum update done after the grafana installation. Exclude grafana for this update.