### PR TITLE
Update to CycleCloud version 8.4

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1117,6 +1117,12 @@
                     "type": "string",
                     "enum": ["20.11.9", "22.05.3"],
                     "description": "SLURM version to install. Currently supported: only 20.11.9 and 22.05.3."
+                },
+                "cyclecloud_slurm_version": {
+                    "type": "string",
+                    "enum": ["2.7.0", "2.7.1"],
+                    "default": "2.7.1",
+                    "description": "CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: only 2.7.0 and 2.7.1."
                 }
             },
             "required": [

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -1,4 +1,4 @@
-i---
+---
 # yaml-language-server: $schema=config.schema.json
 
 # name of the cluster
@@ -227,7 +227,7 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-  # version: 8.3.0-3062 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
+  # version: 8.4.0-3122 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
   # Optional: use Ubuntu for the CycleCloud VM (default: linux_base_image)
   # image: "canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
   # plan: publisher:product:name

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -289,6 +289,8 @@ slurm:
   # SLURM version to install. Currently supported: only 20.11.9 and 22.05.3.
   # Other versions can be installed by building from source (See build_rpms setting in the slurmserver role)
   slurm_version: 20.11.9
+  # CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: only 2.7.0 and 2.7.1. Default to 2.7.1
+  cyclecloud_slurm_version: 2.7.1
   # Name of the SLURM cluster for accounting (optional, default to 'slurm')
   # WARNING: changing this value on a running cluster will cause slurmctld to fail to start. This is a
   # safety check to prevent accounting errors. To override, remove /var/spool/slurmd/clustername

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -658,6 +658,8 @@ slurm:
   # SLURM version to install. Currently supported: only 20.11.9 and 22.05.3.
   # Other versions can be installed by building from source (See build_rpms setting in the slurmserver role)
   slurm_version: 20.11.9
+  # CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: only 2.7.0 and 2.7.1. Default to 2.7.1
+  cyclecloud_slurm_version: 2.7.1
   # Name of the SLURM cluster for accounting (optional, default to 'slurm')
   # WARNING: changing this value on a running cluster will cause slurmctld to fail to start. This is a
   # safety check to prevent accounting errors. To override, remove /var/spool/slurmd/clustername

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -599,7 +599,7 @@ cyclecloud:
   # Optional: use Ubuntu for the CycleCloud VM (default: linux_base_image)
   # image: "canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
   # plan: publisher:product:name
-  # version: 8.3.0-3062 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
+  # version: 8.4.0-3122 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
 
 # Lustre cluster is optional and can be used to create a Lustre cluster in the environment.
 lustre:

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -38,7 +38,7 @@
       cc_storage: '{{global_cc_storage}}'
       cc_domain: '{{domain_name}}'
       cc_ldap_server: '{{ldap_server}}'
-      cc_version: '{{cyclecloud.version | default("8.3.0-3062")}}'
+      cc_version: '{{cyclecloud.version | default("8.4.0-3122")}}'
 
   - name: update packages for security
     become: true

--- a/playbooks/roles/cyclecloud/files/cyclecloud-slurm.txt
+++ b/playbooks/roles/cyclecloud/files/cyclecloud-slurm.txt
@@ -1,0 +1,13 @@
+AdType = "Cloud.Project"
+Version = "2.7.0"
+ProjectType = "scheduler"
+Url = "https://github.com/Azure/cyclecloud-slurm/releases/2.7.0"
+AutoUpgrade = false
+Name = "slurm"
+
+AdType = "Cloud.Project"
+Version = "2.7.1"
+ProjectType = "scheduler"
+Url = "https://github.com/Azure/cyclecloud-slurm/releases/2.7.1"
+AutoUpgrade = false
+Name = "slurm"

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -81,6 +81,11 @@
     src: '{{role_path}}/files/user_role_record.txt'
     dest: /opt/cycle_server/config/data/user_role_record.txt
 
+- name: Add Slurm project version records 
+  copy:
+    src: '{{role_path}}/files/cyclecloud-slurm.txt'
+    dest: /opt/cycle_server/config/data/cyclecloud-slurm.txt
+
 - name: Rebranding record
   copy:
     src: '{{role_path}}/files/brand.json'

--- a/playbooks/roles/cyclecloud_cluster/vars/main.yml
+++ b/playbooks/roles/cyclecloud_cluster/vars/main.yml
@@ -3,7 +3,7 @@ common_project_root: '{{project_root}}/common'
 openpbs_project_root: '{{project_root}}/openpbs'
 enroot_project_root: '{{project_root}}/enroot'
 cc_queue_manager:
-cyclecloud_slurm_release: 2.7.0
+cyclecloud_slurm_release: 2.7.1
 slurm_version: '{{cc_slurm_version}}'
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100

--- a/playbooks/roles/cyclecloud_cluster/vars/main.yml
+++ b/playbooks/roles/cyclecloud_cluster/vars/main.yml
@@ -3,7 +3,7 @@ common_project_root: '{{project_root}}/common'
 openpbs_project_root: '{{project_root}}/openpbs'
 enroot_project_root: '{{project_root}}/enroot'
 cc_queue_manager:
-cyclecloud_slurm_release: 2.7.1
+cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.1")}}'
 slurm_version: '{{cc_slurm_version}}'
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100

--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -50,6 +50,7 @@
   shell: | 
     /tmp/cyclecloud-pbspro/initialize_pbs.sh 
     /tmp/cyclecloud-pbspro/initialize_default_queues.sh
+    source /etc/profile.d/pbs.sh
     /tmp/cyclecloud-pbspro/install.sh  --venv /opt/cycle/pbspro/venv --install-venv
     /tmp/cyclecloud-pbspro/generate_autoscale_json.sh  --install-dir /opt/cycle/pbspro --username {{ cc_admin }} --password "{{ cc_password }}" --url https://ccportal:9443/cyclecloud --cluster-name pbs1
   args:

--- a/playbooks/roles/pbsserver/vars/main.yml
+++ b/playbooks/roles/pbsserver/vars/main.yml
@@ -1,2 +1,2 @@
-cyclecloud_pbspro: 2.0.15
+cyclecloud_pbspro: 2.0.19
 openpbs_version: 19.1.1

--- a/playbooks/roles/slurmserver/defaults/main.yml
+++ b/playbooks/roles/slurmserver/defaults/main.yml
@@ -1,7 +1,7 @@
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100
 slurm_gid: 11100
-cyclecloud_slurm_release: 2.7.1
+cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.1")}}'
 pyxis_version: 0.15.0
 build_rpms: false
 accounting_enabled: false

--- a/playbooks/roles/slurmserver/defaults/main.yml
+++ b/playbooks/roles/slurmserver/defaults/main.yml
@@ -1,7 +1,7 @@
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100
 slurm_gid: 11100
-cyclecloud_slurm_release: 2.7.0
+cyclecloud_slurm_release: 2.7.1
 pyxis_version: 0.15.0
 build_rpms: false
 accounting_enabled: false

--- a/playbooks/roles/slurmserver/tasks/main.yml
+++ b/playbooks/roles/slurmserver/tasks/main.yml
@@ -166,32 +166,6 @@
       - 'slurm-slurmd-{{slurm_version}}.el7.x86_64.rpm'
       - 'slurm-slurmdbd-{{slurm_version}}.el7.x86_64.rpm'
       - 'slurm-torque-{{slurm_version}}.el7.x86_64.rpm'
-
-      # - 'slurm-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-contribs-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-devel-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-example-configs-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-libpmi-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-openlava-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-pam_slurm-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-perlapi-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-slurmctld-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-slurmd-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-slurmdbd-{{slurm_version}}.el8.x86_64.rpm'
-      # - 'slurm-torque-{{slurm_version}}.el8.x86_64.rpm'
-
-      # - 'slurm_{{slurm_version}}_amd64.deb'
-      # - 'slurm-contribs_{{slurm_version}}_amd64.deb'
-      # - 'slurm-devel_{{slurm_version}}_amd64.deb'
-      # - 'slurm-example-configs_{{slurm_version}}_amd64.deb'
-      # - 'slurm-libpmi_{{slurm_version}}_amd64.deb'
-      # - 'slurm-openlava_{{slurm_version}}_amd64.deb'
-      # - 'slurm-pam-slurm_{{slurm_version}}_amd64.deb'
-      # - 'slurm-perlapi_{{slurm_version}}_amd64.deb'
-      # - 'slurm-slurmctld_{{slurm_version}}_amd64.deb'
-      # - 'slurm-slurmd_{{slurm_version}}_amd64.deb'
-      # - 'slurm-slurmdbd_{{slurm_version}}_amd64.deb'
-      # - 'slurm-torque_{{slurm_version}}_amd64.deb'
   when: not build_rpms
 
 - name: query the size of the installed slurm RPM
@@ -316,21 +290,6 @@
     url: https://github.com/Azure/cyclecloud-slurm/releases/download/{{cyclecloud_slurm_release}}/cyclecloud_api-8.1.0-py2.py3-none-any.whl
     dest: /opt/cycle/slurm
     timeout: 180
-
-# - name: download cc jobsubmit plugin
-#   get_url:
-#     url: https://github.com/Azure/cyclecloud-slurm/releases/download/{{cyclecloud_slurm_release}}/job_submit_cyclecloud_centos_{{slurm_version}}.so
-#     dest: /usr/lib64/slurm/job_submit_cyclecloud.so
-#     timeout: 180
-#   when: not build_rpms
-
-# - name: install cc job_submit plugin
-#   copy:
-#     src: '{{homedir_mountpoint}}/slurm/job_submit_cyclecloud.so'
-#     dest: /usr/lib64/slurm/job_submit_cyclecloud.so
-#     mode: 0755
-#     remote_src: yes
-#   when: build_rpms
 
 - name: install cc job_submit.lua plugin
   copy:

--- a/playbooks/scheduler.yml
+++ b/playbooks/scheduler.yml
@@ -42,7 +42,7 @@
     vars:
       cc_admin: '{{admin_user}}'
       cc_password: '{{password.stdout}}'
-      cc_version: '{{cyclecloud.version | default("8.3.0-3062")}}'
+      cc_version: '{{cyclecloud.version | default("8.4.0-3122")}}'
       slurm_version: '{{slurm.slurm_version | default("20.11.9")}}-1'
       accounting_enabled: '{{slurm.accounting_enabled | default(false)}}'
       enroot_scratch_dir: '/mnt/resource'

--- a/tests/configs/config_full.yml
+++ b/tests/configs/config_full.yml
@@ -198,7 +198,7 @@ scheduler:
 # CycleCloud VM configuration
 cyclecloud:
   vm_size: Standard_B2ms
-  version: 8.3.0-3062 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
+  version: 8.4.0-3122 # to specify a specific version, see https://packages.microsoft.com/yumrepos/cyclecloud/
 
 # Lustre cluster is optional and can be used to create a Lustre cluster in the environment.
 lustre:


### PR DESCRIPTION
- Change default to CycleCloud 8.4
- Update cyclecloud-pbs project to 2.0.19
- Update cyclecloud-slurm project to 2.7.1
- added cycle records for supporting cyclecloud-slurm projects 2.7.0 and 2.7.1
- allow uppercase queue names with SLURM
- fix dns registration with SLURM

> Note : This update is specifically targeting cyclecloud-slurm version 2.7.1 as 3.0.1 is a major change and will be treated by #1623

## Upgrade process
rerun these playbooks :
 - ccportal
 - cccluster
 - scheduler

close #1354 
close #1575 
close #657 