### PR TITLE
Do not override OOD dashboard files when winviz is disabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,7 @@ function enable_winviz ()
   if [ "$enable_winviz" == "true" ]; then
     ENABLE_WINVIZ_PLAYBOOK=$PLAYBOOKS_DIR/ood-overrides-guacamole.yml
   else
+    touch $PLAYBOOKS_DIR/guacamole.ok
     touch $PLAYBOOKS_DIR/guac_spooler.ok
     ENABLE_WINVIZ_PLAYBOOK=
   fi

--- a/playbooks/roles/ood-applications/defaults/main.yml
+++ b/playbooks/roles/ood-applications/defaults/main.yml
@@ -14,4 +14,4 @@ ood_azhop_apps:
     - { name: "bc_paraview", enabled: '{{applications.bc_paraview.enabled | default(false)}}' }
     - { name: "bc_rstudio", enabled: '{{applications.bc_rstudio.enabled | default(false)}}' }
     - { name: "bc_vizer", enabled: '{{applications.bc_vizer.enabled | default(false)}}' }
-    - { name: "dashboard", enabled: true }
+    - { name: "dashboard", enabled: '{{enable_remote_winviz | default(false)}}' }

--- a/playbooks/roles/ood-applications/tasks/main.yml
+++ b/playbooks/roles/ood-applications/tasks/main.yml
@@ -11,6 +11,7 @@
     state: "{{'directory' if item.enabled else 'absent'}}"
     mode: 0755
   loop: '{{ood_azhop_apps}}'
+  when: item.name != 'dashboard'
 
 - name: Copy application files
   copy:


### PR DESCRIPTION
This is to prepare Windows Remote Viz deprecation
close #1622 