### PR TITLE
Upgrade to OpenOndemand 3.0.1

### DIFF
--- a/packer/scripts/centos/interactive-desktop-3d.sh
+++ b/packer/scripts/centos/interactive-desktop-3d.sh
@@ -58,8 +58,10 @@ set +e
 echo "################### INSTALL VirtualGL / VNC"
 yum groupinstall -y "X Window system"
 yum groupinstall -y xfce
-yum install -y https://netix.dl.sourceforge.net/project/turbovnc/2.2.5/turbovnc-2.2.5.x86_64.rpm
-yum install -y https://cbs.centos.org/kojifiles/packages/python-websockify/0.8.0/13.el7/noarch/python2-websockify-0.8.0-13.el7.noarch.rpm
+#yum install -y https://netix.dl.sourceforge.net/project/turbovnc/2.2.5/turbovnc-2.2.5.x86_64.rpm
+yum install -y https://yum.osc.edu/ondemand/3.0/compute/el7/x86_64/turbovnc-2.2.5-1.el7.x86_64.rpm
+#yum install -y https://cbs.centos.org/kojifiles/packages/python-websockify/0.8.0/13.el7/noarch/python2-websockify-0.8.0-13.el7.noarch.rpm
+yum install -y https://yum.osc.edu/ondemand/3.0/compute/el7/x86_64/python3-websockify-0.10.0-1.el7.noarch.rpm
 
 wget --no-check-certificate "https://virtualgl.com/pmwiki/uploads/Downloads/VirtualGL.repo" -O /etc/yum.repos.d/VirtualGL.repo
 

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -97,4 +97,4 @@ pun_custom_env:
 # See https://osc.github.io/ood-documentation/latest/customization.html#pinning-applications-to-the-dashboard
 pinned_apps:
   - category: 'Interactive Apps'
-  - sys/shell/ssh/ondemand
+  - sys/shell

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -9,7 +9,7 @@
   vars_files:
     - '{{global_config_file}}'
   vars:
-    ondemand_version: 2.0.29
+    ondemand_version: 3.0.1
     ood_core_version: 0.22.0
     yq_version: v4.25.3
     yq_binary: yq_linux_amd64
@@ -394,6 +394,11 @@
       name: "create passenger tmp directory and set permissions"
       minute: "0,10,20,30,40,50"
       job: "test -e /mnt/resource/passenger-tmp || (mkdir /mnt/resource/passenger-tmp && chmod 777 /mnt/resource/passenger-tmp)"
+
+  # Fix websocket issue https://discourse.openondemand.org/t/novnc-failed-to-connect-to-server-ondemand-3-0-1/2711/23
+  - name: fix websocket attach protocols for OOD 3.0.1
+    shell: |
+      sed -i "s|uri, protocols));|uri, ['binary','base64']));|g" /var/www/ood/apps/sys/dashboard/public/noVNC-1.3.0/core/websock.js
 
   - name: Enable Apache mpm_event_module
     shell: |

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -402,9 +402,10 @@
       job: "test -e /mnt/resource/passenger-tmp || (mkdir /mnt/resource/passenger-tmp && chmod 777 /mnt/resource/passenger-tmp)"
 
   # Fix websocket issue https://discourse.openondemand.org/t/novnc-failed-to-connect-to-server-ondemand-3-0-1/2711/23
-  - name: fix websocket attach protocols for OOD 3.0.1
-    shell: |
-      sed -i "s|uri, protocols));|uri, ['binary','base64']));|g" /var/www/ood/apps/sys/dashboard/public/noVNC-1.3.0/core/websock.js
+  # Not needed if GUI node is using websockify 0.10.0+
+  # - name: fix websocket attach protocols for OOD 3.0.1
+  #   shell: |
+  #     sed -i "s|uri, protocols));|uri, ['binary','base64']));|g" /var/www/ood/apps/sys/dashboard/public/noVNC-1.3.0/core/websock.js
 
   - name: Enable Apache mpm_event_module
     shell: |

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -319,14 +319,14 @@
       path: /etc/ood/config/apps/dashboard/initializers
       state: directory
 
-  - name: create ood lustre menu option
-    lineinfile:
-      path: /etc/ood/config/apps/dashboard/initializers/ood.rb
-      search_string: /lustre
-      line : 'OodFilesApp.candidate_favorite_paths << FavoritePath.new("/lustre", title: "Lustre")'
-      create: yes
-      state: present
-    when: ( lustre.create | default(false) )
+  # - name: create ood lustre menu option
+  #   lineinfile:
+  #     path: /etc/ood/config/apps/dashboard/initializers/ood.rb
+  #     search_string: /lustre
+  #     line : 'OodFilesApp.candidate_favorite_paths << FavoritePath.new("/lustre", title: "Lustre")'
+  #     create: yes
+  #     state: present
+  #   when: ( lustre.create | default(false) )
 
   - name: Create "{{mounts[item].mountpoint}}" directory mountpoint
     file:
@@ -346,15 +346,21 @@
     loop: "{{mounts | list}}"
     when: item != 'home'
 
-  - name: create mount "{{mounts[item].mountpoint}}" menu option
-    lineinfile:
-      path: /etc/ood/config/apps/dashboard/initializers/ood.rb
-      search_string: '{{mounts[item].mountpoint}}'
-      line : 'OodFilesApp.candidate_favorite_paths << FavoritePath.new("{{mounts[item].mountpoint}}", title: "{{item}}" )'
-      create: yes
-      state: present
-    loop: "{{mounts | list}}"
-    when: item != 'home'
+# https://osc.github.io/ood-documentation/latest/customizations.html#add-shortcuts-to-files-menu
+  - name: Copy the file menu initializer
+    template:
+      src: 'ood.rb.j2'
+      dest: '/etc/ood/config/apps/dashboard/initializers/ood.rb'
+
+  # - name: create mount "{{mounts[item].mountpoint}}" menu option
+  #   lineinfile:
+  #     path: /etc/ood/config/apps/dashboard/initializers/ood.rb
+  #     search_string: '{{mounts[item].mountpoint}}'
+  #     line : 'OodFilesApp.candidate_favorite_paths << FavoritePath.new("{{mounts[item].mountpoint}}", title: "{{item}}" )'
+  #     create: yes
+  #     state: present
+  #   loop: "{{mounts | list}}"
+  #   when: item != 'home'
 
   # Update file upload staging area to be in /mnt/resource
   - name: Create passenger temp dir

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -439,13 +439,13 @@
 
   - name: create OOD_VERSION if not exists
     shell: |
-      cp /opt/ood/VERSION /opt/ood/OOD_VERSION
+      cp /opt/ood/VERSION /opt/ood/{{ondemand_version}}
     args: 
-      creates: /opt/ood/OOD_VERSION
+      creates: /opt/ood/{{ondemand_version}}
 
   - name: retrieve OnDemand version
     shell: |
-      cat /opt/ood/OOD_VERSION
+      cat /opt/ood/{{ondemand_version}}
     register: ood_version
 
   - name: Override OOD version with azhop version

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/centos/fix_websockify.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/files/centos/fix_websockify.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# If websockify 0.8.0 is installed, remove it and install release 0.10.0
+grep "0.8.0" /usr/bin/websockify
+if [ $? -eq 0 ]; then
+    yum remove -y python2-websockify
+    yum install -y https://yum.osc.edu/ondemand/3.0/compute/el7/x86_64/python3-websockify-0.10.0-1.el7.noarch.rpm
+fi

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/5-default.sh.j2
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Pre-requisites:
 # - jq installed
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$script_dir/../files/azhop-helpers.sh" 
+read_os
 
 # Apply default configuration to the node
 # Remote read access to the cluster init script files for all users
@@ -24,6 +27,10 @@ case $VM_SIZE in
     sed -i '/Section "Device"/a\    Option         "HardDPMS" "false"' /etc/X11/xorg.conf
     echo "Enabling GUI"
     systemctl restart gdm
+    
+    if [ -e $script_dir/../files/$os_release/fix_websockify.sh ]; then
+      $script_dir/../files/$os_release/fix_websockify.sh
+    fi
   ;;
 esac
 

--- a/playbooks/templates/ood.rb.j2
+++ b/playbooks/templates/ood.rb.j2
@@ -1,0 +1,12 @@
+Rails.application.config.after_initialize do
+{% for mount in mounts %}
+    {% if mount != 'home' %}
+    OodFilesApp.candidate_favorite_paths << FavoritePath.new("{{mounts[mount].mountpoint}}", title: "{{mount}}" )
+    {% endif %}
+
+{% endfor %}
+{% if lustre.create | default(false) %}
+    OodFilesApp.candidate_favorite_paths << FavoritePath.new("/lustre", title: "Lustre")
+{% endif %}
+
+end


### PR DESCRIPTION
- updated version to 3.0.1
- remove websockify 0.8.0 and replace by 0.10.0 on CentOS 7.9
- fix the pinned shell app 
- new file menu initializers to support new syntax
- update CentOS 79 image with websockify 0.10.0

close #1460 