### PR TITLE
Fixed the branch name regex for the portal UI

### DIFF
--- a/marketplace/solution/ui_definition.json
+++ b/marketplace/solution/ui_definition.json
@@ -127,7 +127,7 @@
         "toolTip": "Branch of the azhop repo to pull - Default to main",
         "constraints": {
           "required": false,
-          "regex": "^[a-zA-Z0-9](?:[a-zA-Z0-9_\\-\\.]*[a-zA-Z0-9])?$",
+          "regex": "^[A-Za-z0-9_\\-/]+$",
           "validationMessage": "Invalid branch name"
         },
         "visible": true


### PR DESCRIPTION
This allows "/" in the branch name