### PR TITLE
switch to cyclecloud-slurm 2.7.2 by default

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1133,9 +1133,9 @@
                 },
                 "cyclecloud_slurm_version": {
                     "type": "string",
-                    "enum": ["2.7.0", "2.7.1"],
-                    "default": "2.7.1",
-                    "description": "CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: only 2.7.0 and 2.7.1."
+                    "enum": ["2.7.0", "2.7.1", "2.7.2"],
+                    "default": "2.7.2",
+                    "description": "CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: 2.7.0-2.7.2."
                 }
             },
             "required": [

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -297,8 +297,8 @@ slurm:
   # SLURM version to install. Currently supported: only 20.11.9 and 22.05.3.
   # Other versions can be installed by building from source (See build_rpms setting in the slurmserver role)
   slurm_version: 20.11.9
-  # CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: only 2.7.0 and 2.7.1. Default to 2.7.1
-  cyclecloud_slurm_version: 2.7.1
+  # CycleCloud for SLURM project version as defined in https://github.com/Azure/cyclecloud-slurm/releases. Currently supported: 2.7.0-2.7.2. Default to 2.7.2
+  cyclecloud_slurm_version: 2.7.2
   # Name of the SLURM cluster for accounting (optional, default to 'slurm')
   # WARNING: changing this value on a running cluster will cause slurmctld to fail to start. This is a
   # safety check to prevent accounting errors. To override, remove /var/spool/slurmd/clustername

--- a/playbooks/roles/cyclecloud/files/cyclecloud-slurm.txt
+++ b/playbooks/roles/cyclecloud/files/cyclecloud-slurm.txt
@@ -11,3 +11,10 @@ ProjectType = "scheduler"
 Url = "https://github.com/Azure/cyclecloud-slurm/releases/2.7.1"
 AutoUpgrade = false
 Name = "slurm"
+
+AdType = "Cloud.Project"
+Version = "2.7.2"
+ProjectType = "scheduler"
+Url = "https://github.com/Azure/cyclecloud-slurm/releases/2.7.2"
+AutoUpgrade = false
+Name = "slurm"

--- a/playbooks/roles/cyclecloud_cluster/vars/main.yml
+++ b/playbooks/roles/cyclecloud_cluster/vars/main.yml
@@ -3,7 +3,7 @@ common_project_root: '{{project_root}}/common'
 openpbs_project_root: '{{project_root}}/openpbs'
 enroot_project_root: '{{project_root}}/enroot'
 cc_queue_manager:
-cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.1")}}'
+cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.2")}}'
 slurm_version: '{{cc_slurm_version}}'
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100

--- a/playbooks/roles/slurmserver/defaults/main.yml
+++ b/playbooks/roles/slurmserver/defaults/main.yml
@@ -1,7 +1,7 @@
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100
 slurm_gid: 11100
-cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.1")}}'
+cyclecloud_slurm_release: '{{slurm.cyclecloud_slurm_version | default("2.7.2")}}'
 pyxis_version: 0.15.0
 build_rpms: false
 accounting_enabled: false


### PR DESCRIPTION
2.7.2 fixes an important bug when CycleCloud is run in "standalone DNS" mode [1]

[1] https://github.com/Azure/cyclecloud-slurm/releases/tag/2.7.2