### PR TITLE
Update packages and reboot if needed

### DIFF
--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -40,10 +40,10 @@
       cc_ldap_server: '{{ldap_server}}'
       cc_version: '{{cyclecloud.version | default("8.4.0-3122")}}'
 
-  - name: update packages for security
-    become: true
-    yum:
-      name: '*'
-      state: latest
-      exclude: cyclecloud*
-    when: ansible_distribution == "CentOS"
+  - name: Update Packages
+    include_role:
+      name: pkg_update
+      apply: 
+        become: true
+    vars:
+      packages_to_exclude_from_upgrade: "cyclecloud*"

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -75,9 +75,10 @@
             path: /etc/grafana/provisioning/dashboards
             foldersFromFilesStructure: true
 
-  - name: update packages for security
-    become: true
-    yum:
-      name: '*'
-      state: latest
-      exclude: grafana*
+  - name: Update Packages
+    include_role:
+      name: pkg_update
+      apply: 
+        become: true
+    vars:
+      packages_to_exclude_from_upgrade: "grafana*"

--- a/playbooks/linux.yml
+++ b/playbooks/linux.yml
@@ -21,11 +21,10 @@
     service:
       name: sshd
       state: restarted
-  - name: update packages for security
-    become: true
-    yum:
-      name: '*'
-      state: latest
+  - name: Update Packages
+    include_role:
+      name: pkg_update
+
 
 - name: Join AD domain or create local users, mount shared home
   hosts: scheduler, ondemand, grafana

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -484,9 +484,10 @@
     vars:
       marker_file: cccluster.ok
 
-  - name: update packages for security
-    become: true
-    yum:
-      name: '*'
-      state: latest
-      exclude: kernel*,kmod*,amlfs*,ondemand*
+  - name: Update Packages
+    include_role:
+      name: pkg_update
+      apply: 
+        become: true
+    vars:
+      packages_to_exclude_from_upgrade: "ondemand*"

--- a/playbooks/roles/cyclecloud/tasks/AlmaLinux.yml
+++ b/playbooks/roles/cyclecloud/tasks/AlmaLinux.yml
@@ -4,15 +4,9 @@
     state: disabled
   register: selinux
 
-- name: reboot 
-  reboot:
-  when: selinux.reboot_required 
-
-- name: Update packages marked for security
-  yum:
-    state: latest
-    security: yes
-    lock_timeout : 180
+# - name: reboot 
+#   reboot:
+#   when: selinux.reboot_required 
 
 - name: install AZ CLI repo (CentOS)
   shell: |

--- a/playbooks/roles/cyclecloud/tasks/CentOS.yml
+++ b/playbooks/roles/cyclecloud/tasks/CentOS.yml
@@ -4,15 +4,9 @@
     state: disabled
   register: selinux
 
-- name: reboot 
-  reboot:
-  when: selinux.reboot_required 
-
-- name: Update packages marked for security
-  yum:
-    state: latest
-    security: yes
-    lock_timeout : 180
+# - name: reboot 
+#   reboot:
+#   when: selinux.reboot_required 
 
 - name: install AZ CLI repo (CentOS)
   shell: |

--- a/playbooks/roles/pkg_update/tasks/AlmaLinux.yml
+++ b/playbooks/roles/pkg_update/tasks/AlmaLinux.yml
@@ -1,0 +1,19 @@
+---
+- name: update packages
+  become: true
+  dnf:
+    name: '*'
+    state: latest
+    exclude: "{{ packages_to_exclude_from_upgrade }}"
+    lock_timeout : 180
+
+- name: check if reboot is required
+  command: "/usr/bin/needs-restarting -r"
+  register: reboot_required
+  changed_when: false
+  failed_when: reboot_required.rc == 2
+  ignore_errors: true
+
+- name: reboot 
+  reboot:
+  when: reboot_required.rc == 1

--- a/playbooks/roles/pkg_update/tasks/CentOS.yml
+++ b/playbooks/roles/pkg_update/tasks/CentOS.yml
@@ -1,0 +1,19 @@
+---
+- name: update packages
+  become: true
+  yum:
+    name: '*'
+    state: latest
+    exclude: "{{ packages_to_exclude_from_upgrade }}"
+    lock_timeout : 180
+
+- name: check if reboot is required
+  command: "/usr/bin/needs-restarting -r"
+  register: reboot_required
+  changed_when: false
+  failed_when: reboot_required.rc == 2
+  ignore_errors: true
+
+- name: reboot 
+  reboot:
+  when: reboot_required.rc == 1

--- a/playbooks/roles/pkg_update/tasks/Ubuntu.yml
+++ b/playbooks/roles/pkg_update/tasks/Ubuntu.yml
@@ -1,0 +1,24 @@
+---
+- name: Update apt-cache
+  apt:
+    update_cache: yes
+
+- name: Prevent packages from being upgraded
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ packages_to_exclude_from_upgrade }}"
+
+- name: Update all packages to their latest version
+  ansible.builtin.apt:
+    name: "*"
+    state: latest
+
+- name: Check if reboot is required
+  stat:
+    path: /var/run/reboot-required
+  register: reboot_required
+
+- name: Reboot if required
+  reboot:
+  when: reboot_required.stat.exists == true

--- a/playbooks/roles/pkg_update/tasks/main.yml
+++ b/playbooks/roles/pkg_update/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Perform OS dependent configuration tasks
+  include_tasks: "{{ansible_distribution}}.yml"
+

--- a/playbooks/roles/pkg_update/vars/main.yml
+++ b/playbooks/roles/pkg_update/vars/main.yml
@@ -1,0 +1,1 @@
+packages_to_exclude_from_upgrade: ""

--- a/playbooks/roles/slurmserver/tasks/main.yml
+++ b/playbooks/roles/slurmserver/tasks/main.yml
@@ -192,6 +192,14 @@
     lock_timeout : 180
   loop: '{{slurm_server_packages}}'
 
+- name: Update slurm service to start after the home directory is mounted
+  lineinfile:
+    path: /usr/lib/systemd/system/slurmctld.service
+    insertafter: 'ConditionPathExists='
+    line: 'RequiresMountsFor={{homedir_mountpoint}}'
+    state: present
+    firstmatch: yes
+
 - name: create slurm config
   template:
     src: slurm.conf.j2

--- a/playbooks/scheduler.yml
+++ b/playbooks/scheduler.yml
@@ -48,9 +48,8 @@
       enroot_scratch_dir: '/mnt/resource'
     when: ( queue_manager is defined and queue_manager == "slurm" )
 
-  - name: update packages for security
-    become: true
-    yum:
-      name: '*'
-      state: latest
-#      exclude: kernel*,kmod*,amlfs*
+  - name: Update Packages
+    include_role:
+      name: pkg_update
+      apply: 
+        become: true


### PR DESCRIPTION
- new ansible role for CentOS, Alma, Ubuntu to update packages and reboot if required
- role applied on jumbox, grafana, ccportal, scheduler and ondemand VMs
- add a constraint in slurmctld.service to start slurmctld once the NFS mount hosting slurm.conf is ready