### PR TITLE
OpenPBS: set missing ccportal_name variable

### DIFF
--- a/playbooks/roles/pbsserver/vars/main.yml
+++ b/playbooks/roles/pbsserver/vars/main.yml
@@ -1,1 +1,2 @@
 cyclecloud_pbspro: 2.0.19
+ccportal_name: "{{cyclecloud.name | default('ccportal')}}"


### PR DESCRIPTION
Fix to set ccportal_name for OnePBS. Was a regretion after introducing PR #1667 
close #1716 