### PR TITLE
Allow to set OIDCStateMaxNumberOfCookies

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -357,6 +357,7 @@ authentication:
   #   OIDCPassIDTokenAs: # for AAD use 'serialized'
   #   OIDCPassRefreshToken: # for AAD use 'On'
   #   OIDCPassClaimsAs: # for AAD use 'environment'
+  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to '10 true'
 
 image_gallery:
   create: false # Create the shared image gallery to store custom images

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -357,7 +357,7 @@ authentication:
   #   OIDCPassIDTokenAs: # for AAD use 'serialized'
   #   OIDCPassRefreshToken: # for AAD use 'On'
   #   OIDCPassClaimsAs: # for AAD use 'environment'
-  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to '10 true'
+  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to [10, true]
 
 image_gallery:
   create: false # Create the shared image gallery to store custom images

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -726,6 +726,7 @@ authentication:
   #   OIDCPassIDTokenAs: # for AAD use 'serialized'
   #   OIDCPassRefreshToken: # for AAD use 'On'
   #   OIDCPassClaimsAs: # for AAD use 'environment'
+  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to '10 true'
 
 image_gallery:
   create: true # Create the shared image gallery to store custom images

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -726,7 +726,7 @@ authentication:
   #   OIDCPassIDTokenAs: # for AAD use 'serialized'
   #   OIDCPassRefreshToken: # for AAD use 'On'
   #   OIDCPassClaimsAs: # for AAD use 'environment'
-  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to '10 true'
+  #   OIDCStateMaxNumberOfCookies: # in case of too many connections error for the same user set this to [10, true]
 
 image_gallery:
   create: true # Create the shared image gallery to store custom images

--- a/playbooks/ood-overrides-auth-oidc.yml
+++ b/playbooks/ood-overrides-auth-oidc.yml
@@ -19,4 +19,4 @@ ood_auth_openidc:
   OIDCPassIDTokenAs: '{{authentication.ood_auth_openidc.OIDCPassIDTokenAs}}'
   OIDCPassRefreshToken: '{{authentication.ood_auth_openidc.OIDCPassRefreshToken}}'
   OIDCPassClaimsAs: '{{authentication.ood_auth_openidc.OIDCPassClaimsAs}}'
-  OIDCStateMaxNumberOfCookies: "{{authentication.ood_auth_openidc.OIDCStateMaxNumberOfCookies | default('[7 true]')}}"
+  OIDCStateMaxNumberOfCookies: '{{authentication.ood_auth_openidc.OIDCStateMaxNumberOfCookies | default([7, true])}}'

--- a/playbooks/ood-overrides-auth-oidc.yml
+++ b/playbooks/ood-overrides-auth-oidc.yml
@@ -19,4 +19,4 @@ ood_auth_openidc:
   OIDCPassIDTokenAs: '{{authentication.ood_auth_openidc.OIDCPassIDTokenAs}}'
   OIDCPassRefreshToken: '{{authentication.ood_auth_openidc.OIDCPassRefreshToken}}'
   OIDCPassClaimsAs: '{{authentication.ood_auth_openidc.OIDCPassClaimsAs}}'
-#  OIDCStateMaxNumberOfCookies: "{{authentication.ood_auth_openidc.OIDCStateMaxNumberOfCookies | default('7 true')}}"
+  OIDCStateMaxNumberOfCookies: "{{authentication.ood_auth_openidc.OIDCStateMaxNumberOfCookies | default('[7 true]')}}"

--- a/playbooks/ood-overrides-auth-oidc.yml
+++ b/playbooks/ood-overrides-auth-oidc.yml
@@ -19,3 +19,4 @@ ood_auth_openidc:
   OIDCPassIDTokenAs: '{{authentication.ood_auth_openidc.OIDCPassIDTokenAs}}'
   OIDCPassRefreshToken: '{{authentication.ood_auth_openidc.OIDCPassRefreshToken}}'
   OIDCPassClaimsAs: '{{authentication.ood_auth_openidc.OIDCPassClaimsAs}}'
+#  OIDCStateMaxNumberOfCookies: "{{authentication.ood_auth_openidc.OIDCStateMaxNumberOfCookies | default('7 true')}}"


### PR DESCRIPTION
Allow OIDCStateMaxNumberOfCookies to be set to automatically drop old cookies.
Set default to 7 and drop

close #1696 