### PR TITLE
AlmaLinux - upgrade python and PIP dependencies

### DIFF
--- a/playbooks/roles/cyclecloud/tasks/AlmaLinux.yml
+++ b/playbooks/roles/cyclecloud/tasks/AlmaLinux.yml
@@ -37,9 +37,16 @@
 
 - name: Install pre-reqs packages
   yum:
-    name: azure-cli, dnsmasq, unzip, java
+    name: azure-cli, dnsmasq, unzip, java, python39, python39-pip
     state: present
     lock_timeout : 180
+
+- name: Upgrade PIP
+  shell: |
+    set -e
+    alternatives --set python /usr/bin/python3.9
+    alternatives --set python3 /usr/bin/python3.9
+    python3 -m pip install --upgrade pip
 
 - name: Install CycleCloud
   yum:


### PR DESCRIPTION
To support installation of CycleCloud 8.4.2.x
close #1730 