### PR TITLE
Resolve CycleCloud CLI installation on CentOS 79

### DIFF
--- a/playbooks/roles/cyclecloud/tasks/CentOS.yml
+++ b/playbooks/roles/cyclecloud/tasks/CentOS.yml
@@ -43,9 +43,29 @@
 
 - name: Install pre-reqs packages
   yum:
-    name: azure-cli, dnsmasq, unzip, gcc, openssl-devel, bzip2-devel, libffi-devel, zlib-devel, openssl11, openssl11-libs, openssl11-devel
+    name: azure-cli, dnsmasq, unzip, gcc, bzip2-devel, libffi-devel, zlib-devel
     state: present
     lock_timeout : 180
+
+- name: Install OpenSSL
+  unarchive: 
+    src: "https://github.com/openssl/openssl/releases/download/openssl-1.1.1w/openssl-1.1.1w.tar.gz"
+    dest: /tmp/
+    remote_src: yes
+  args:
+    creates: /usr/local/openssl
+
+- name: Build OpenSSL
+  shell: |
+    set -e
+    cd /tmp/openssl-1.1.1w
+    ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl
+    make
+    make install
+    echo "/usr/local/openssl/lib" > /etc/ld.so.conf.d/openssl.conf
+    ldconfig
+  args:
+    creates: /usr/local/openssl
 
 - name: download Python 3.9  
   unarchive: 
@@ -59,7 +79,7 @@
   shell: |
     set -e
     cd /tmp/Python-3.9.18
-    ./configure --enable-optimizations
+    ./configure --enable-optimizations --with-openssl=/usr/local/openssl
     make altinstall
   args:
     creates: /usr/local/bin/python3.9

--- a/playbooks/roles/cyclecloud/tasks/CentOS.yml
+++ b/playbooks/roles/cyclecloud/tasks/CentOS.yml
@@ -47,9 +47,9 @@
     state: present
     lock_timeout : 180
 
-- name: Install OpenSSL
+- name: Download OpenSSL
   unarchive: 
-    src: "https://github.com/openssl/openssl/releases/download/openssl-1.1.1w/openssl-1.1.1w.tar.gz"
+    src: "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz"
     dest: /tmp/
     remote_src: yes
   args:
@@ -63,6 +63,7 @@
     make
     make install
     echo "/usr/local/openssl/lib" > /etc/ld.so.conf.d/openssl.conf
+    ln -s /etc/ssl/certs/ca-bundle.trust.crt /usr/local/openssl/cert.pem
     ldconfig
   args:
     creates: /usr/local/openssl

--- a/playbooks/roles/cyclecloud/tasks/CentOS.yml
+++ b/playbooks/roles/cyclecloud/tasks/CentOS.yml
@@ -35,11 +35,40 @@
   args:
     creates: /etc/yum.repos.d/cyclecloud.repo
 
-- name: Install pre-reqs packages
+- name: Install epel-release
   yum:
-    name: azure-cli, dnsmasq, unzip
+    name: epel-release
     state: present
     lock_timeout : 180
+
+- name: Install pre-reqs packages
+  yum:
+    name: azure-cli, dnsmasq, unzip, gcc, openssl-devel, bzip2-devel, libffi-devel, zlib-devel, openssl11, openssl11-libs, openssl11-devel
+    state: present
+    lock_timeout : 180
+
+- name: download Python 3.9  
+  unarchive: 
+    src: "https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz"
+    dest: /tmp/
+    remote_src: yes
+  args:
+    creates: /usr/local/bin/python3.9
+
+- name: Build Python 3.9
+  shell: |
+    set -e
+    cd /tmp/Python-3.9.18
+    ./configure --enable-optimizations
+    make altinstall
+  args:
+    creates: /usr/local/bin/python3.9
+
+- name: Upgrade PIP
+  shell: |
+    set -e
+    alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.9 1
+    python3 -m pip install --upgrade pip
 
 - name: Install CycleCloud
   yum:

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -25,6 +25,14 @@
 - name: Perform OS dependent configuration tasks
   include_tasks: "{{ansible_distribution}}.yml"
 
+- name: Update Packages
+  include_role:
+    name: pkg_update
+    apply: 
+      become: true
+  vars:
+    packages_to_exclude_from_upgrade: "cyclecloud*"
+
 - name: Create a data record for azhop and start cycleserver
   shell: |
     set -e
@@ -48,7 +56,7 @@
     CS_ROOT=/opt/cycle_server
     unzip $CS_ROOT/tools/cyclecloud-cli.zip
     cd cyclecloud-cli-installer
-    ./install.sh --system -y
+    ./install.sh --system -y -v
     cd $mydir
     # Update properties
     sed -i 's/webServerMaxHeapSize\=2048M/webServerMaxHeapSize\=4096M/' $CS_ROOT/config/cycle_server.properties


### PR DESCRIPTION
- download and build OpenSSL 1.1.1w
- download and build Python 3.9.18
- configure certificates to used the bundled ones

close #1733 