### PR TITLE
fix for issue in some hpc images causing lustre performance degradation

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
@@ -39,3 +39,8 @@ fi
 
 # TODO : don't chmod 777, but instead reorganize lustre directories structure and permissions
 chmod 777 $lustre_mount
+
+# Fix the read-ahead issue present in some HPC images
+for bdi in /sys/devices/virtual/bdi/lustrefs-* ; do
+  echo 0 > $bdi/read_ahead_kb
+done

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
@@ -42,5 +42,7 @@ chmod 777 $lustre_mount
 
 # Fix the read-ahead issue present in some HPC images
 for bdi in /sys/devices/virtual/bdi/lustrefs-* ; do
-  echo 0 > $bdi/read_ahead_kb
+  if [ -d $bdi ] ; then
+    echo 0 > $bdi/read_ahead_kb
+  fi
 done

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/2-mountlustre.sh.j2
@@ -42,7 +42,7 @@ chmod 777 $lustre_mount
 
 # Fix the read-ahead issue present in some HPC images
 for bdi in /sys/devices/virtual/bdi/lustrefs-* ; do
-  if [ -d $bdi ] ; then
+  if [ -e $bdi/read_ahead_kb ] ; then
     echo 0 > $bdi/read_ahead_kb
   fi
 done


### PR DESCRIPTION
Some HPC images incorrectly set read_ahead value to all devices which leads to performance issue with Lustre.
This fix sets Lustre read_ahead_kb=0 after the mount.

related azhpc-images issue: https://github.com/Azure/azhpc-images/issues/293
