### PR TITLE
Revert "Use external auth module (mod_authnz_external) for CycleCloud Proxy."

### DIFF
--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -32,10 +32,9 @@
       state: latest
       lock_timeout : 180
 
-  - name: Set up mod_authnz_external modules (for cyclecloud proxy)
-    yum:
-      name: mod_authnz_external
-      lock_timeout: 180  
+  - name: Set up PAM authentication for OOD
+    include_role:
+      name: ood_pam_auth
 
   - name: Retrieve OIDC secret
     block:
@@ -233,13 +232,12 @@
         if ! grep -q {{ccportal_name}} /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb; then
           cd /root
           cat << EOF > cyclecloud_proxy
-          DefineExternalAuth pwauth pipe /usr/bin/pwauth
           SetEnv OOD_CC_URI "/cyclecloud"
           <Location "/cyclecloud">
             AuthType Basic
             AuthName "Open OnDemand"
-            AuthBasicProvider external
-            AuthExternal pwauth
+            AuthBasicProvider PAM
+            AuthPAMService ood
             Require valid-user
 
             ProxyPass http://{{ccportal_name}}:80/cyclecloud


### PR DESCRIPTION
Reverts Azure/az-hop#1754 as it failed when not using AD on both CentOS and AlmaLinux 8.7
https://github.com/phokz/mod-auth-external there seems to also be security risks using this method