### PR TITLE
Security feature: Configure max file upload size and allowed extensions

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1007,7 +1007,9 @@
                 "vm_size": { "type": "string" },
                 "name": { "type": "string", "default": "ondemand", "maxLength": 15, "pattern": "[0-9a-z\\-]+" },
                 "generate_certificate": { "type": "boolean", "default": true },
-                "fqdn": { "type": "string" }
+                "fqdn": { "type": "string" },
+                "file_upload_max": { "type": "integer" },
+                "file_upload_allowed_extensions": { "type": "array" }
             },
             "required": [
                 "vm_size"

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -233,6 +233,8 @@ ondemand:
   vm_size: Standard_D4s_v5
   #fqdn: azhop.foo.com # When provided it will be used for the certificate server name
   generate_certificate: true # Generate an SSL certificate for the OnDemand portal. Default to true
+  #file_upload_max: 2048 # Maximum file upload size in bytes. Optional, default: 10GB
+  #file_upload_allowed_extensions: [".txt", ".log"] # List of allowed file extensions. Default: all files are allowed
 # Grafana VM configuration
 grafana:
   name: grafana

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -601,6 +601,8 @@ ondemand:
   vm_size: Standard_D4s_v5
   #fqdn: azhop.foo.com # When provided it will be used for the certificate server name
   generate_certificate: true # Generate an SSL certificate for the OnDemand portal. Default to true
+  #file_upload_max: 2048 # Maximum file upload size in bytes. Optional, default: 10GB
+  #file_upload_allowed_extensions: [".txt", ".log"] # List of allowed file extensions. Default: all files are allowed
 # Grafana VM configuration
 grafana:
   vm_size: Standard_B2ms

--- a/playbooks/ood-overrides-common.yml
+++ b/playbooks/ood-overrides-common.yml
@@ -30,6 +30,7 @@ ood_apps:
   dashboard:
     env:
       ood_bc_dynamic_js: true
+      file_upload_max: "{{ondemand.file_upload_max | default(omit)}}"
 
   bc_desktop:
     title: "Linux Desktop"

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -361,6 +361,14 @@
       regexp: 'limit: 1,$'
       replace: 'limit: 1, timeout: 0,'
 
+  - name: Enable file extension restriction in Uppy
+    lineinfile:
+      path: /var/www/ood/apps/sys/dashboard/app/views/files/index.html.erb
+      regex: 'allowedFileTypes'
+      state: "{{ 'present' if (ondemand.file_upload_allowed_extensions is defined) else 'absent' }}"
+      insertafter: 'restrictions:'
+      line: '      allowedFileTypes: {{ ondemand.file_upload_allowed_extensions | default("[]") }},'
+
   - name: create cron entry to make sure the passenger-tmp folder exists
     cron:
       name: "create passenger tmp directory and set permissions"

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -365,9 +365,10 @@
     lineinfile:
       path: /var/www/ood/apps/sys/dashboard/app/views/files/index.html.erb
       regex: 'allowedFileTypes'
-      state: "{{ 'present' if (ondemand.file_upload_allowed_extensions is defined) else 'absent' }}"
+      state: 'present'
       insertafter: 'restrictions:'
       line: '      allowedFileTypes: {{ ondemand.file_upload_allowed_extensions | default("[]") }},'
+    when: (ondemand.file_upload_allowed_extensions is defined)
 
   - name: create cron entry to make sure the passenger-tmp folder exists
     cron:


### PR DESCRIPTION
Added two optional settings to config.yml:
`ondemand.file_upload_max` - max file size in bytes allowed for upload
`ondemand.file_upload_allowed_extensions` - array of extensions or mime types allowed to upload