### PR TITLE
Use mod_authnz_external for Apache authentication instead of PAM

### DIFF
--- a/playbooks/ood-overrides-auth-basic.yml
+++ b/playbooks/ood-overrides-auth-basic.yml
@@ -5,3 +5,8 @@ httpd_auth:
 - AuthBasicProvider external
 - AuthExternal pwauth
 - Require valid-user
+
+# Thee will be the value to used when this https://github.com/OSC/ood-ansible/issues/222 will be fixed
+httpd_extra: |
+  AddExternalAuth pwauth /usr/bin/pwauth
+  SetExternalAuthMethod pwauth pipe

--- a/playbooks/ood-overrides-auth-basic.yml
+++ b/playbooks/ood-overrides-auth-basic.yml
@@ -2,6 +2,6 @@
 httpd_auth:
 - AuthType Basic
 - AuthName "Open OnDemand"
-- AuthBasicProvider PAM
-- AuthPAMService ood
+- AuthBasicProvider external
+- AuthExternal pwauth
 - Require valid-user

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -230,6 +230,15 @@
       slurm_version: '{{slurm.slurm_version | default("20.11.9")}}-1'
     when: ( queue_manager is defined and queue_manager == "slurm" )
 
+  # temporary workaround waiting for this https://github.com/OSC/ood-ansible/issues/222 to be fixed
+  - name: Configure pwauth for Apache
+    blockinfile:
+      path: /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
+      insertafter: OOD_PUN_STAGE_CMD
+      block: |
+        AddExternalAuth pwauth /usr/bin/pwauth
+        SetExternalAuthMethod pwauth pipe
+
   - name: setup cyclecloud proxy
     shell: |
         if ! grep -q {{ccportal_name}} /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb; then

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -32,9 +32,10 @@
       state: latest
       lock_timeout : 180
 
-  - name: Set up PAM authentication for OOD
-    include_role:
-      name: ood_pam_auth
+  - name: Set up mod_authnz_external modules (for cyclecloud proxy)
+    yum:
+      name: mod_authnz_external,pwauth
+      lock_timeout: 180  
 
   - name: Retrieve OIDC secret
     block:
@@ -238,8 +239,8 @@
           <Location "/cyclecloud">
             AuthType Basic
             AuthName "Open OnDemand"
-            AuthBasicProvider PAM
-            AuthPAMService ood
+            AuthBasicProvider external
+            AuthExternal pwauth
             Require valid-user
 
             ProxyPass http://{{ccportal_name}}:80/cyclecloud


### PR DESCRIPTION
Switch from PAM to external to support AD on AlmaLinux 8.7

close #1683 

