### PR TITLE
dynamically set httpd_auth based on distro

### DIFF
--- a/playbooks/ood-overrides-auth-basic.yml
+++ b/playbooks/ood-overrides-auth-basic.yml
@@ -1,12 +1,2 @@
 ---
-httpd_auth:
-- AuthType Basic
-- AuthName "Open OnDemand"
-- AuthBasicProvider external
-- AuthExternal pwauth
-- Require valid-user
-
-# Thee will be the value to used when this https://github.com/OSC/ood-ansible/issues/222 will be fixed
-httpd_extra: |
-  AddExternalAuth pwauth /usr/bin/pwauth
-  SetExternalAuthMethod pwauth pipe
+# left empty intentionally

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -21,6 +21,36 @@
   - name: Gather facts for first time
     setup:
 
+  - name: set httpd_auth values when using basic auth
+    block:
+      - name: set httpd_auth values when using basic auth on Alma 8
+        set_fact:
+          httpd_auth:
+            - AuthType Basic
+            - AuthName "Open OnDemand"
+            - AuthBasicProvider external
+            - AuthExternal pwauth
+            - Require valid-user
+        when:
+          - ansible_distribution == 'AlmaLinux'
+          - ansible_distribution_major_version == '8'      
+
+      - name: set httpd_auth values when using basic auth on CentOS 7
+        set_fact:
+          httpd_auth:
+            - AuthType Basic
+            - AuthName "Open OnDemand"
+            - AuthBasicProvider PAM
+            - AuthPAMService ood
+            - Require valid-user
+        when:
+          - ansible_distribution == 'CentOS'
+          - ansible_distribution_major_version == '7'  
+
+    when:
+      - authentication.httpd_auth is defined
+      - authentication.httpd_auth == 'basic'
+
   # - name: debug
   #   debug:
   #     msg: 
@@ -32,10 +62,20 @@
       state: latest
       lock_timeout : 180
 
+  - name: Set up PAM authentication for OOD
+    include_role:
+      name: ood_pam_auth
+    when: 
+      - ansible_distribution == 'CentOS'
+      - ansible_distribution_major_version == '7'
+
   - name: Set up mod_authnz_external modules (for cyclecloud proxy)
     yum:
       name: mod_authnz_external,pwauth
       lock_timeout: 180  
+    when: 
+      - ansible_distribution == 'AlmaLinux'
+      - ansible_distribution_major_version == '8'
 
   - name: Retrieve OIDC secret
     block:
@@ -238,29 +278,25 @@
       block: |
         AddExternalAuth pwauth /usr/bin/pwauth
         SetExternalAuthMethod pwauth pipe
+    when: 
+      - ansible_distribution == 'AlmaLinux'
+      - ansible_distribution_major_version == '8'
 
   - name: setup cyclecloud proxy
-    shell: |
-        if ! grep -q {{ccportal_name}} /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb; then
-          cd /root
-          cat << EOF > cyclecloud_proxy
+    blockinfile:
+      path: /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
+      insertafter: EOF
+      block: |
           SetEnv OOD_CC_URI "/cyclecloud"
           <Location "/cyclecloud">
-            AuthType Basic
-            AuthName "Open OnDemand"
-            AuthBasicProvider external
-            AuthExternal pwauth
-            Require valid-user
+            {% for auth in httpd_auth  %}
+            {{ auth }}
+            {% endfor %}
 
             ProxyPass http://{{ccportal_name}}:80/cyclecloud
             ProxyPassReverse http://{{ccportal_name}}:80/cyclecloud
           </Location>
-        EOF
-          sed -i '$e cat cyclecloud_proxy' /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
-          rm cyclecloud_proxy
-          /opt/ood/ood-portal-generator/sbin/update_ood_portal
-        fi
-
+  
   - name: Configure Lmod
     block:
       - name: enable powertools

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -275,10 +275,13 @@
     blockinfile:
       path: /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
       insertafter: OOD_PUN_STAGE_CMD
+      marker: "# {mark} ANSIBLE MANAGED BLOCK - Configure pwauth for Apache"
       block: |
-        AddExternalAuth pwauth /usr/bin/pwauth
-        SetExternalAuthMethod pwauth pipe
+          AddExternalAuth pwauth /usr/bin/pwauth
+          SetExternalAuthMethod pwauth pipe
     when: 
+      - authentication.httpd_auth is defined
+      - authentication.httpd_auth == 'basic'
       - ansible_distribution == 'AlmaLinux'
       - ansible_distribution_major_version == '8'
 
@@ -286,6 +289,7 @@
     blockinfile:
       path: /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
       insertafter: EOF
+      marker: "# {mark} ANSIBLE MANAGED BLOCK - setup cyclecloud proxy"
       block: |
           SetEnv OOD_CC_URI "/cyclecloud"
           <Location "/cyclecloud">


### PR DESCRIPTION
- set httpd_auth using set_fact in the ood_playbook => close #1773 
- dynamically build the cyclecloud proxy => this will use the same httpd_auth rather than always use PAM => close #1669 

