### PR TITLE
Use `unique_name` as OIDC claim

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -357,7 +357,7 @@ authentication:
   # ood_auth_openidc:
   #   OIDCProviderMetadataURL: # for AAD use 'https://sts.windows.net/{{tenant_id}}/.well-known/openid-configuration'
   #   OIDCClientID: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
-  #   OIDCRemoteUserClaim: # for AAD use 'upn'
+  #   OIDCRemoteUserClaim: # for AAD use 'unique_name'
   #   OIDCScope: # for AAD use 'openid profile email groups'
   #   OIDCPassIDTokenAs: # for AAD use 'serialized'
   #   OIDCPassRefreshToken: # for AAD use 'On'


### PR DESCRIPTION
`unique_name` is a _required_ claim, while `upn` is not [1].

In AD, the `upn` claim only exists for regular organizational accounts, not for guest users in the tenant [2].

[1] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/55c0a84d-48e7-4043-91f8-9ebd0a51ab68

[2] https://stackoverflow.com/a/51979475/1069467