### PR TITLE
updating slurm stats script to work with python3

### DIFF
--- a/playbooks/telegraf.yml
+++ b/playbooks/telegraf.yml
@@ -205,14 +205,14 @@
           mode: 0755
           owner: telegraf
           content: |
-            #!/usr/bin/env python
+            #!/usr/bin/env python3
 
             import json
             import subprocess
             import sys
 
             def sinfo():
-                for sinfo_line in subprocess.check_output(["/bin/sinfo", "-h", "-o", "%R %D %F %T"]).split('\n'):
+                for sinfo_line in subprocess.check_output(["/bin/sinfo", "-h", "-o", "%R %D %F %T"]).decode().split('\n'):
                     data = sinfo_line.split(' ')
                     if (data[0] != ''):
                         partition = data[0]
@@ -227,7 +227,7 @@
                 jobs_pending = 0
                 jobs_configuring = 0
                 jobs_other = 0
-                for sinfo_line in subprocess.check_output(["/bin/squeue", "-h", "-o", "%a %D %T %P"]).split('\n'):
+                for sinfo_line in subprocess.check_output(["/bin/squeue", "-h", "-o", "%a %D %T %P"]).decode().split('\n'):
                     data = sinfo_line.split(' ')
                     if (data[0] != ''):
                         account = data[0]


### PR DESCRIPTION
In a recent marketplace deployment I realized that the monitoring dashboards were not working: 

![image](https://github.com/Azure/az-hop/assets/115099460/61ed535a-a009-456d-b39d-beb122f7a119)

I realized that it was due to the fact that the scheduler VM had an upgraded version of python and the script to collect some of the required metrics needed to be updated to use python3. 