### PR TITLE
Update azhop-slurm.txt.j2

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -135,7 +135,6 @@ echo "cloud-init done" >> /tmp/cloud-init.txt
         cyclecloud.cluster.autoscale.idle_time_before_jobs = {{queue.idle_timeout}}
       {% endif %}
         [[[cluster-init enroot:default:1.0.0]]]
-      {% endif %}
       {% if queue.name.startswith('viz') %}
         [[[cluster-init cryosparc:default:1.0.0]]]
       {% endif %}


### PR DESCRIPTION
line 138 has an extra `{% endif % }` that causes failure during configuration