### PR TITLE
Automatically configure GPU count in integrated Open OnDemand applications

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -181,17 +181,6 @@
                         "$ref": "#/definitions/Queue"
                     }
                 },
-                "enable_remote_winviz": {
-                    "description": "",
-                    "type": "boolean"
-                },
-                "remoteviz": {
-                    "description": "Remote visualization configuration",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Queue"
-                    }
-                },
                 "applications": {
                     "description": "Configure applications in OnDemand web portal",
                     "$ref": "#/definitions/Applications"

--- a/playbooks/cccluster.yml
+++ b/playbooks/cccluster.yml
@@ -85,7 +85,6 @@
       cc_password: '{{password.stdout}}'
       cc_ad_join_password: '{{ad_join_password.stdout | default("")}}'
       cc_queues: '{{queues}}'
-      cc_remoteviz: '{{remoteviz}}'
       cc_image_lookup: '{{image_lookup}}'
       cc_domain: '{{domain_name}}'
       cc_queue_manager: '{{ queue_manager | default("openpbs") }}'

--- a/playbooks/nodearray_lookup.yml
+++ b/playbooks/nodearray_lookup.yml
@@ -35,7 +35,7 @@
           set -e
           set -o pipefail
           mkdir -p /etc/ood/config/apps/bc_desktop/config
-          curl -k --connect-timeout 30 -u "{{admin_user}}:{{user_password.stdout}}" "https://{{cyclecloud.name | default('ccportal')}}:9443/cyclecloud/clusters/{{cluster_name}}/status?nodes" | jq '[.nodearrays[] | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount}]' | yq e -P > /etc/ood/config/apps/bc_desktop/config/node_arrays.yml
+          curl -k --connect-timeout 30 -u "{{admin_user}}:{{user_password.stdout}}" "https://{{cyclecloud.name | default('ccportal')}}:9443/cyclecloud/clusters/{{cluster_name}}/status?nodes" | jq '[.nodearrays[] | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount}]' | yq e -P > /etc/ood/config/apps/bc_desktop/config/node_arrays.yml
       args:
         executable: /bin/bash
       delegate_to: ondemand

--- a/playbooks/ood-overrides-slurm.yml
+++ b/playbooks/ood-overrides-slurm.yml
@@ -18,23 +18,20 @@ ood_apps:
           scheduler_args += ["-t", "%02d:00:00" % hours]
         end
 
-        if target == "viz3d" or target == "largeviz3d"
-          scheduler_args += ["--gpus=1"]
-        end
-
         # If the user has specified a node ratio greather than 1, set the job ppn
         node_ratio = bucket.to_i
+        node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+        slot_type = node_arrays.find { |slot_type| slot_type["name"] == target }
+        gpu_count = slot_type["gpuCount"].to_i
         if node_ratio > 1
-          node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
-          node_arrays.each do |slot_type|
-            if slot_type["name"] == target
-              cores = (slot_type["vcpuCount"].to_i / node_ratio)
-              scheduler_args += ["--ntasks-per-node=%d" % cores]
-              break
-            end
-          end
+          cores = (slot_type["vcpuCount"].to_i / node_ratio)
+          gpu_count = (gpu_count.to_f / node_ratio.to_f).ceil
+          scheduler_args += ["--ntasks-per-node=%d" % cores]
         else
           scheduler_args += ["--exclusive"]
+        end
+        if gpu_count > 0
+          scheduler_args += ["--gpus=%d" % gpu_count]
         end
 
       -%>

--- a/playbooks/roles/cyclecloud_cluster/defaults/all.yml
+++ b/playbooks/roles/cyclecloud_cluster/defaults/all.yml
@@ -5,5 +5,4 @@ cc_domain:
 cc_password:
 cc_ad_join_password:
 cc_queues:
-cc_remoteviz:
 cc_queue_manager: 'openpbs'

--- a/playbooks/roles/ood-applications/files/bc_ansys_workbench/submit.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_ansys_workbench/submit.yml.erb
@@ -8,22 +8,20 @@ node_ratio = bucket.to_i
 if OodAppkit.clusters[cluster].job_config[:adapter] == 'slurm'
   scheduler_args = ["-p", target]
 
-  if target == "viz3d" or target == "largeviz3d"
-    scheduler_args += ["--gpus=1"]
-  end
-
   # If the user has specified a node ratio greather than 1, set the job ppn
+  slot_type = node_arrays.find { |slot_type| slot_type["name"] == target }
+  gpu_count = slot_type["gpuCount"].to_i
   if node_ratio > 1
-    node_arrays.each do |slot_type|
-      if slot_type["name"] == target
-        cores = (slot_type["vcpuCount"].to_i / node_ratio)
-        scheduler_args += ["--ntasks-per-node=%d" % cores]
-        break
-      end
-    end
+    cores = (slot_type["vcpuCount"].to_i / node_ratio)
+    gpu_count = (gpu_count.to_f / node_ratio.to_f).ceil
+    scheduler_args += ["--ntasks-per-node=%d" % cores]
   else
     scheduler_args += ["--exclusive"]
   end
+  if gpu_count > 0
+    scheduler_args += ["--gpus=%d" % gpu_count]
+  end
+
 else
   scheduler_args = ["-q", "vizq"]
   if node_ratio > 1

--- a/playbooks/roles/ood-applications/files/bc_paraview/form.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_paraview/form.yml.erb
@@ -3,7 +3,7 @@ cluster:
     - "ondemand"
 form:
     - bc_num_hours
-    - bc_slot_type
+    - target
     - bucket
     - version
     - paraview_home
@@ -17,7 +17,7 @@ attributes:
         help: |
             This is the maximum duration in hours of your session once started.
         step: 1
-    bc_slot_type:
+    target:
         widget: "select"
         label: "Node type"
         help: |

--- a/playbooks/roles/ood-applications/files/bc_paraview/submit.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_paraview/submit.yml.erb
@@ -7,29 +7,28 @@ node_ratio = bucket.to_i
 node_count = 1
 
 if OodAppkit.clusters[cluster].job_config[:adapter] == 'slurm'
-  scheduler_args = ["-p", bc_slot_type]
-  if bc_slot_type == "viz3d" or bc_slot_type == "largeviz3d"
-    scheduler_args += ["--gpus=1"]
-  end
+  scheduler_args = ["-p", target]
 
   # If the user has specified a node ratio greather than 1, set the job ppn
+  slot_type = node_arrays.find { |slot_type| slot_type["name"] == target }
+  gpu_count = slot_type["gpuCount"].to_i
   if node_ratio > 1
-    node_arrays.each do |slot_type|
-      if slot_type["name"] == bc_slot_type
-        cores = (slot_type["vcpuCount"].to_i / node_ratio)
-        scheduler_args += ["--ntasks-per-node=%d" % cores]
-        break
-      end
-    end
+    cores = (slot_type["vcpuCount"].to_i / node_ratio)
+    gpu_count = (gpu_count.to_f / node_ratio.to_f).ceil
+    scheduler_args += ["--ntasks-per-node=%d" % cores]
   else
     scheduler_args += ["--exclusive"]
   end
+  if gpu_count > 0
+    scheduler_args += ["--gpus=%d" % gpu_count]
+  end
+
 else
   scheduler_args = ["-q", "vizq"]
   node_arrays.each do |slot_type|
-    if slot_type["name"] == bc_slot_type
+    if slot_type["name"] == target
       cores = (slot_type["vcpuCount"].to_i / node_ratio)
-      scheduler_args += ["-l", "select=%d:slot_type=%s:ncpus=%d:mpiprocs=%d" % [node_count, bc_slot_type, cores, cores]]
+      scheduler_args += ["-l", "select=%d:slot_type=%s:ncpus=%d:mpiprocs=%d" % [node_count, target, cores, cores]]
       break
     end
   end

--- a/playbooks/roles/ood-applications/files/bc_paraview/template/script.sh.erb
+++ b/playbooks/roles/ood-applications/files/bc_paraview/template/script.sh.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-<%- gpu = context.bc_slot_type.include?("3d") -%>
+<%- gpu = context.target.include?("3d") -%>
 
 # Clean the environment
 module purge

--- a/playbooks/roles/ood-applications/files/bc_paraview/template/script.sh.erb
+++ b/playbooks/roles/ood-applications/files/bc_paraview/template/script.sh.erb
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-<%- gpu = context.target.include?("3d") -%>
+<%- 
+require "yaml"
+node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+slot_type = node_arrays.find { |slot_type| slot_type["name"] == context.target }
+
+gpu_count = slot_type["gpuCount"].to_i 
+-%>
 
 # Clean the environment
 module purge
@@ -11,7 +17,7 @@ cd "${HOME}"
 # Launch Xfce Window Manager and Panel
 source "<%= session.staged_root.join("xfce_kiosk.sh") %>"
 
-<%- if gpu -%>
+<%- if gpu_count > 0 -%>
 GL_LAUNCHER="vglrun"
 PARAVIEW_SERVER_IMPL="egl"
 PARAVIEW_EXTRA_ARGS=

--- a/playbooks/roles/ood-applications/files/bc_vizer/form.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_vizer/form.yml.erb
@@ -3,7 +3,7 @@ cluster:
     - "ondemand"
 form:
     - bc_num_hours
-    - bc_slot_type
+    - target
     - bucket
     - container_image
     - dataset
@@ -17,7 +17,7 @@ attributes:
         help: |
             This is the maximum duration in hours of your session once started.
         step: 1
-    bc_slot_type:
+    target:
         widget: "select"
         label: "Node type"
         help: |

--- a/playbooks/roles/ood-applications/files/bc_vizer/submit.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_vizer/submit.yml.erb
@@ -10,37 +10,34 @@ dataset_filename = File.basename(dataset)
 dataset_dir = File.dirname(dataset)
 
 if OodAppkit.clusters[cluster].job_config[:adapter] == 'slurm'
-  scheduler_args = ["-p", bc_slot_type]
-  if bc_slot_type == "viz3d" or bc_slot_type == "largeviz3d"
-    scheduler_args += ["--gpus=1"]
-    gl = "egl"
-  else
-    gl = "osmesa"
-  end
+  scheduler_args = ["-p", target]
 
-  scheduler_args += ["--container-image=%s" % container_image.gsub("${gl}", gl)]
   scheduler_args += ["--container-mounts=%s:/opt/datasets:ro" % dataset_dir]
   scheduler_args += ["--export=ALL"]
  
   # If the user has specified a node ratio greather than 1, set the job ppn
+  slot_type = node_arrays.find { |slot_type| slot_type["name"] == target }
+  gpu_count = slot_type["gpuCount"].to_i
+  gl = "osmesa"
   if node_ratio > 1
-    node_arrays.each do |slot_type|
-      if slot_type["name"] == bc_slot_type
-        cores = (slot_type["vcpuCount"].to_i / node_ratio)
-        scheduler_args += ["--ntasks-per-node=%d" % cores]
-        break
-      end
-    end
+    cores = (slot_type["vcpuCount"].to_i / node_ratio)
+    gpu_count = (gpu_count.to_f / node_ratio.to_f).ceil
+    scheduler_args += ["--ntasks-per-node=%d" % cores]
   else
     scheduler_args += ["--exclusive"]
   end
+  if gpu_count > 0
+    scheduler_args += ["--gpus=%d" % gpu_count]
+    gl = "egl"
+  end
+  scheduler_args += ["--container-image=%s" % container_image.gsub("${gl}", gl)]
 
 else
   scheduler_args = ["-q", "vizq"]
   node_arrays.each do |slot_type|
-    if slot_type["name"] == bc_slot_type
+    if slot_type["name"] == target
       cores = (slot_type["vcpuCount"].to_i / node_ratio)
-      scheduler_args += ["-l", "select=%d:slot_type=%s:ncpus=%d:mpiprocs=%d" % [node_count, bc_slot_type, cores, cores]]
+      scheduler_args += ["-l", "select=%d:slot_type=%s:ncpus=%d:mpiprocs=%d" % [node_count, target, cores, cores]]
       break
     end
   end

--- a/playbooks/roles/ood-applications/files/bc_vizer/template/before.sh.erb
+++ b/playbooks/roles/ood-applications/files/bc_vizer/template/before.sh.erb
@@ -11,7 +11,7 @@ port=$(find_port ${host})
 export CONTAINER_NAME=trame.$PBS_JOBID
 
 # replace '${gl}' with the appropriate value
-<%- if context.bc_slot_type == 'viz3d' or context.bc_slot_type == 'largeviz3d' -%>
+<%- if context.target == 'viz3d' or context.target == 'largeviz3d' -%>
 gl=egl
 <%- else -%>
 gl=osmesa

--- a/playbooks/roles/ood-applications/files/bc_vizer/template/before.sh.erb
+++ b/playbooks/roles/ood-applications/files/bc_vizer/template/before.sh.erb
@@ -10,8 +10,16 @@ port=$(find_port ${host})
 # use the job ID for the container name
 export CONTAINER_NAME=trame.$PBS_JOBID
 
+<%- 
+require "yaml"
+node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+slot_type = node_arrays.find { |slot_type| slot_type["name"] == context.target }
+
+gpu_count = slot_type["gpuCount"].to_i 
+-%>
+
+<%- if gpu_count > 0 -%>
 # replace '${gl}' with the appropriate value
-<%- if context.target == 'viz3d' or context.target == 'largeviz3d' -%>
 gl=egl
 <%- else -%>
 gl=osmesa

--- a/playbooks/roles/ood-applications/files/bc_vmd/readme.md
+++ b/playbooks/roles/ood-applications/files/bc_vmd/readme.md
@@ -6,6 +6,8 @@ Adapted from https://github.com/OSC/bc_osc_vmd
 ## Prerequisites
 
 [VMD] need to be installed on a file share system accessible by the nodes. 
+Download, exatract and follow instructions in the README file.
+
 The default VMD root directory is defined as `/anfhome/apps/vmd`, but it can be changed in the `form.yml.erb` file and is a parameter in the UI.
 
 ## Enabling the OnDemand application
@@ -25,7 +27,6 @@ $ ./install.sh ood-custom
 ```
 
 [VMD]: http://www.ks.uiuc.edu/Research/vmd/
-
 ## License
 
 * VMD and its logo are intellectual property owned by the University of Illinois, and all right, 

--- a/playbooks/roles/ood-applications/files/bc_vmd/submit.yml.erb
+++ b/playbooks/roles/ood-applications/files/bc_vmd/submit.yml.erb
@@ -8,22 +8,20 @@ node_ratio = bucket.to_i
 if OodAppkit.clusters[cluster].job_config[:adapter] == 'slurm'
   scheduler_args = ["-p", target]
 
-  if target == "viz3d" or target == "largeviz3d"
-    scheduler_args += ["--gpus=1"]
-  end
-
   # If the user has specified a node ratio greather than 1, set the job ppn
+  slot_type = node_arrays.find { |slot_type| slot_type["name"] == target }
+  gpu_count = slot_type["gpuCount"].to_i
   if node_ratio > 1
-    node_arrays.each do |slot_type|
-      if slot_type["name"] == target
-        cores = (slot_type["vcpuCount"].to_i / node_ratio)
-        scheduler_args += ["--ntasks-per-node=%d" % cores]
-        break
-      end
-    end
+    cores = (slot_type["vcpuCount"].to_i / node_ratio)
+    gpu_count = (gpu_count.to_f / node_ratio.to_f).ceil
+    scheduler_args += ["--ntasks-per-node=%d" % cores]
   else
     scheduler_args += ["--exclusive"]
   end
+  if gpu_count > 0
+    scheduler_args += ["--gpus=%d" % gpu_count]
+  end
+
 else
   scheduler_args = ["-q", "vizq"]
   if node_ratio > 1

--- a/playbooks/roles/ood-applications/files/bc_vmd/template/script.sh.erb
+++ b/playbooks/roles/ood-applications/files/bc_vmd/template/script.sh.erb
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+<%- 
+require "yaml"
+node_arrays = YAML.load_file("/etc/ood/config/apps/bc_desktop/config/node_arrays.yml")
+slot_type = node_arrays.find { |slot_type| slot_type["name"] == context.target }
 
-<%- gpu = context.target.include?("3d") -%>
+gpu_count = slot_type["gpuCount"].to_i 
+-%>
 
 # Clean the environment
 module purge
@@ -21,7 +26,7 @@ source "<%= session.staged_root.join("xfce_kiosk.sh") %>"
 VMD_HOME_DIR="<%= context.vmd_home %>"
 
 set -x
-<%- if gpu -%>
+<%- if gpu_count > 0 -%>
 xfce4-terminal -e "vglrun $VMD_HOME_DIR/bin/vmd" -T "VMD Terminal" --disable-server
 <%- else -%>
 xfce4-terminal -e "$VMD_HOME_DIR/bin/vmd" -T "VMD Terminal" --disable-server


### PR DESCRIPTION
Remove the hardcoded names used to decide if the job needs GPU or not.
- new gpuCount property in the nodearray lookup file created by reading the node status from CycleCloud
- update application ruby code to dynamically load the gpu count

