### PR TITLE
validate uniqueness of uids

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,21 @@ function install_ondemand()
   fi
 }
 
+function validate_uids ()
+{
+  # validate that all uids are unique
+  uids=$(yq eval '.users[] | .uid' $AZHOP_CONFIG)
+  if [ "$uids" != "null" ]; then
+    # uniq -d only prints duplicate lines
+    duplicates=$(echo $uids | tr ' ' '\n' | sort | uniq -d)
+    if [ "$duplicates" != "" ]; then
+      echo "Error: duplicate uid(s) $duplicates detected in config.yml"
+      exit 1
+    fi
+  fi
+}
+
+
 # Ensure submodule exists
 if [ ! -d "${PLAYBOOKS_DIR}/roles/ood-ansible/.github" ]; then
     printf "Installing OOD Ansible submodule\n"
@@ -150,6 +165,7 @@ fi
 
 # Validate config against schema
 $THIS_DIR/validate_config.sh config.yml
+validate_uids
 
 get_scheduler
 get_ood_auth

--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,7 @@ function install_ondemand()
 function validate_uids ()
 {
   # validate that all uids are unique
-  uids=$(yq eval '.users[] | .uid' $AZHOP_CONFIG)
+  uids=$(yq eval '.users[] | .uid' config.yml)
   if [ "$uids" != "null" ]; then
     # uniq -d only prints duplicate lines
     duplicates=$(echo $uids | tr ' ' '\n' | sort | uniq -d)


### PR DESCRIPTION
Clusters have been broken several time because we added users with uids that overlapped with existing uids.

Here we add a simple validation that causes ./install.sh to abort if non-unique uids are detected in the config file.