### PR TITLE
flag to disable NHC per queue

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1133,6 +1133,11 @@
                     "description": "Whether the remote visualization node can be shared by multiple users. Defaults to false",
                     "type": "boolean",
                     "default": false
+                },
+                "healthchecks": {
+                    "description": "Whether to enable healthchecks. Defaults to true",
+                    "type": "boolean",
+                    "default": true
                 }
             },
             "required": [

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -489,6 +489,8 @@ queues:
     MaxScaleSetSize: 100
     # Use ephemeral boot disk for VM, check here for supported family https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
     EphemeralOSDisk: false
+    # Whether to enable healthchecks. Defaults to true
+    healthchecks: false
   - name: hpc
     vm_size: Standard_HB120rs_v3
     max_count: 10

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/8-configure-nhc.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/8-configure-nhc.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Don't configure NHC if not enabled
+enabled_nhc=$(jetpack config healthchecks.enabled | tr '[:upper:]' '[:lower:]')
+if [[ $enabled_nhc != "true" ]]; then
+    exit 0
+fi
+
+
 # Install NHC if not already installed in the image
-if [ ! -d /opt/azurehpc/test/azurehpc-health-checks ] ; then
+az_nhc_installed_version=$(grep Azure-NHC /opt/azurehpc/test/azurehpc-health-checks/docs/version.log | cut -d':' -f2 | xargs)
+az_nhc_target_version="v0.2.7"
+
+if [ "$az_nhc_installed_version" != "$az_nhc_target_version" ] ; then
+    if [ -d /opt/azurehpc/test/azurehpc-health-checks ]; then
+        rm -rf /opt/azurehpc/test/azurehpc-health-checks
+    fi
     mkdir -p /opt/azurehpc/test/
     cd /opt/azurehpc/test/
-    git clone https://github.com/Azure/azurehpc-health-checks.git -b v0.2.6
+    git clone https://github.com/Azure/azurehpc-health-checks.git -b v0.2.7
     cd azurehpc-health-checks
     ./install-nhc.sh
-    cp /opt/azurehpc/test/azurehpc-health-checks/customTests/*.nhc /etc/nhc/scripts
 fi
 
 # Install azhop-node-offline.sh

--- a/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/99-healthcheck.sh
+++ b/playbooks/roles/cyclecloud_cluster/projects/common/cluster-init/scripts/99-healthcheck.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
+# Don't run health checks if not enabled
+enabled_nhc=$(jetpack config healthchecks.enabled | tr '[:upper:]' '[:lower:]')
+if [[ $enabled_nhc != "true" ]]; then
+    exit 0
+fi
 NHC_CONFIG_FILE="/etc/nhc/nhc.conf"
 
-errormessage=$( /opt/azurehpc/test/azurehpc-health-checks/run-health-checks.sh -c $NHC_CONFIG_FILE 2>&1)
-error=$?
+# if run-health-checks.sh exists, then runit
+if [ -e /opt/azurehpc/test/azurehpc-health-checks/run-health-checks.sh ]; then
+    errormessage=$( /opt/azurehpc/test/azurehpc-health-checks/run-health-checks.sh -c $NHC_CONFIG_FILE 2>&1)
+    error=$?
 
-# In case of health check failure, shutdown the node by calling the script /usr/libexec/nhc/azhop-node-offline.sh
-if [ $error -eq 1 ]; then
-    /usr/libexec/nhc/azhop-node-offline.sh $(hostname) "$errormessage"
-    JETPACK=/opt/cycle/jetpack/bin/jetpack
-    $JETPACK shutdown --unhealthy
+    # In case of health check failure, shutdown the node by calling the script /usr/libexec/nhc/azhop-node-offline.sh
+    if [ $error -eq 1 ]; then
+        /usr/libexec/nhc/azhop-node-offline.sh $(hostname) "$errormessage"
+        JETPACK=/opt/cycle/jetpack/bin/jetpack
+        $JETPACK shutdown --unhealthy
+    fi
+else
+    echo "ERROR: /opt/azurehpc/test/azurehpc-health-checks/run-health-checks.sh does not exist"
+    exit 1
 fi

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-OpenPBS.txt.j2
@@ -80,6 +80,7 @@ Autoscale = true
     ImagePlan.Name = {{ plan_details[2] }}
   {% endif %}
         [[[configuration]]]
+        healthchecks.enabled = {{ queue.healthchecks | default(true) }}
         pbspro.slot_type = {{ queue.name }}
         # Specific Autoscale settings
         {% if queue.idle_timeout is defined %}

--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -136,6 +136,7 @@ echo "cloud-init done" >> /tmp/cloud-init.txt
     ImagePlan.Name = {{ plan_details[2] }}
   {% endif %}
         [[[configuration]]]
+        healthchecks.enabled = {{ queue.healthchecks | default(true) }}
         slurm.partition = {{ queue.name }}
       {% if loop.index == 1 %}
         slurm.default_partition = true


### PR DESCRIPTION
- new boolean property `healthchecks` to enable or disable Node Health Checks per queue. Default being true.
- upgraded to azurehpc-health-checks version 0.2.7

close #1807 