### PR TITLE
azhop admins are CycleCloud super users and Administrator

### DIFF
--- a/playbooks/roles/cyclecloud/files/user_role_record.txt
+++ b/playbooks/roles/cyclecloud/files/user_role_record.txt
@@ -9,9 +9,3 @@ Description = "Basic GUI access"
 GroupRole = false
 Name = "User"
 Allow = {"Package.Release/View","System/AccessWebSite","Alerts/Manage","Clusters/View","Clusters/Access", "Fixed.ClusterMetadata"}
-
-AdType = "Application.Role"
-Description = "AZHOP Cluster Admin"
-GroupRole = false
-Name = "azhop Cluster Admin"
-Allow = {"Clusters/Manage", "Fixed.ClusterMetadata"}

--- a/playbooks/templates/local_user_record.txt.j2
+++ b/playbooks/templates/local_user_record.txt.j2
@@ -2,10 +2,11 @@ AdType = "AuthenticatedUser"
 Name =  "{{ user.name }}"
 Authentication = "internal"
 {% if (usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | selectattr('name', 'match', 'azhop-admins') | map(attribute='name') | count ) > 0 %}
-Roles = {"azhop Cluster Admin"}
+Roles = {"Administrator"}
+Superuser = true
 {% else %}
 Roles = {"User"}
+Superuser = false
 {% endif %}
 UID = {{ user.uid }}
-Superuser = false
 RawPassword = "{{password.stdout}}"

--- a/playbooks/templates/user_record.txt.j2
+++ b/playbooks/templates/user_record.txt.j2
@@ -3,11 +3,12 @@ AdType = "AuthenticatedUser"
 Name =  "{{ user.name }}"
 Authentication = "active_directory"
 {% if (usergroups | selectattr('gid', 'in', (user.groups | default([], true))) | selectattr('name', 'match', 'azhop-admins') | map(attribute='name') | count ) > 0 %}
-Roles = {"azhop Cluster Admin"}
+Roles = {"Administrator"}
+Superuser = true
 {% else %}
 Roles = {"User"}
+Superuser = false
 {% endif %}
 UID = {{ user.uid }}
-Superuser = false
 
 {% endfor %}


### PR DESCRIPTION
Relaxing azhop admins permissions on CycleCloue and allowing full feature access. This will make support easier and provide a better fine control of the environment. The drawback is that all manual updates won't be automated and some settings could be lost upon the next redeployment.

- removing the AZHOP Cluster Admin role
- users in the azhop-admins group are now CycleCloud superuser and administrator

close #1645 