### PR TITLE
public IP for CycleCloud if OnDemand is not deployed

### DIFF
--- a/bicep/azhop.bicep
+++ b/bicep/azhop.bicep
@@ -314,6 +314,7 @@ var config = {
         sku: azhopConfig.cyclecloud.vm_size
         osdisksku: 'StandardSSD_LRS'
         image: 'cyclecloud_base'
+        pip: enablePublicIP && !deployOnDemand
         datadisks: [
           {
             name: '${vmNamesMap.ccportal}-datadisk0'

--- a/bicep/vm.bicep
+++ b/bicep/vm.bicep
@@ -17,7 +17,7 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2022-07-01' = if (contain
   name: '${name}-pip'
   location: location
   sku: {
-    name: 'Basic'
+    name: 'Standard'
   }
   properties: {
     publicIPAllocationMethod: 'Static'

--- a/marketplace/solution/build.sh
+++ b/marketplace/solution/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 # This script builds the ARM template and UI definition for the azhop marketplace solution
-BUILD_NAME=${1:-main}
-OFFER=${2:-azhop}
+BUILD_NAME=$(git branch | grep "*" | cut -d' ' -f 2)
+OFFER=${1-azhop}
 
 CONFIG_FILE=${OFFER}/marketplace_config.yml
 UI_DEFINITION=${OFFER}/ui_definition.json


### PR DESCRIPTION
Add a public IP for CycleCloud if public ip is enabled and Open OnDemand not deployed