### PR TITLE
new web_server_path parameter for CycleCloud

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -616,6 +616,11 @@
                     "description": "If set to true, will use the CycleCloud VM as the deployer VM",
                     "type": "boolean",
                     "default": false
+                },
+                "web_server_path" : {
+                    "type": "string",
+                    "description": "Path to the web server path. Defaults to /cyclecloud",
+                    "default": "/cyclecloud"
                 }
             },
             "required": [

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -262,6 +262,8 @@ cyclecloud:
   # Change this to, e.g., 2222, if security policies (like "zero trust") in your tenant automatically block access to port 22 from the internet
   # ssh_port: 2222
   # use_as_deployer: true # default to false - to be used when deploying without a deployer VM
+  # web_server_path: /cyclecloud # Override the CycleCloud Web Server Context Path - default to /cyclecloud
+
 
 # Lustre cluster is optional and can be used to create a Lustre cluster in the environment.
 lustre:

--- a/playbooks/ccportal.yml
+++ b/playbooks/ccportal.yml
@@ -40,6 +40,7 @@
       cc_ldap_server: '{{ldap_server}}'
       cc_version: '{{cyclecloud.version | default("")}}'
       install_cyclecloud: '{{not "azurecyclecloud" in (cyclecloud.image | default(""))}}' # don't install cyclecloud when using the azurecyclecloud marketplace image
+      cc_webserverpath: '{{cyclecloud.web_server_path | default("")}}'
 
   - name: Update Packages
     include_role:

--- a/playbooks/nodearray_lookup.yml
+++ b/playbooks/nodearray_lookup.yml
@@ -35,7 +35,7 @@
           set -e
           set -o pipefail
           mkdir -p /etc/ood/config/apps/bc_desktop/config
-          curl -k --connect-timeout 30 -u "{{admin_user}}:{{user_password.stdout}}" "https://{{cyclecloud.name | default('ccportal')}}:9443/cyclecloud/clusters/{{cluster_name}}/status?nodes" | jq '[.nodearrays[] | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount}]' | yq e -P > /etc/ood/config/apps/bc_desktop/config/node_arrays.yml
+          curl -k --connect-timeout 30 -u "{{admin_user}}:{{user_password.stdout}}" "https://{{cyclecloud.name | default('ccportal')}}:9443{{cyclecloud.web_server_path | default('/cyclecloud')}}/clusters/{{cluster_name}}/status?nodes" | jq '[.nodearrays[] | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount}]' | yq e -P > /etc/ood/config/apps/bc_desktop/config/node_arrays.yml
       args:
         executable: /bin/bash
       delegate_to: ondemand

--- a/playbooks/ood.yml
+++ b/playbooks/ood.yml
@@ -13,6 +13,7 @@
     yq_version: v4.40.5
     yq_binary: yq_linux_amd64
     ccportal_name: "{{cyclecloud.name | default('ccportal')}}"
+    web_server_path: "{{cyclecloud.web_server_path | default('/cyclecloud')}}"
 
   tasks:
   - name: Wait 300 seconds for the nodes to be ready
@@ -291,14 +292,14 @@
       insertafter: EOF
       marker: "# {mark} ANSIBLE MANAGED BLOCK - setup cyclecloud proxy"
       block: |
-          SetEnv OOD_CC_URI "/cyclecloud"
-          <Location "/cyclecloud">
+          SetEnv OOD_CC_URI "{{web_server_path}}"
+          <Location "{{web_server_path}}">
             {% for auth in httpd_auth  %}
             {{ auth }}
             {% endfor %}
 
-            ProxyPass http://{{ccportal_name}}:80/cyclecloud
-            ProxyPassReverse http://{{ccportal_name}}:80/cyclecloud
+            ProxyPass http://{{ccportal_name}}:80{{web_server_path}}
+            ProxyPassReverse http://{{ccportal_name}}:80{{web_server_path}}
           </Location>
   
   - name: Configure Lmod

--- a/playbooks/roles/cyclecloud/defaults/main.yml
+++ b/playbooks/roles/cyclecloud/defaults/main.yml
@@ -1,1 +1,2 @@
 cyclecloud_version: "{{'8.4.2-3186' if (cc_version | default('', true) | trim == '') else cc_version}}"
+cycle_webServerContextPath: "{{'/cyclecloud' if (cc_webserverpath | default('', true) | trim == '') else cc_webserverpath}}"

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -78,7 +78,7 @@
 
 - name: Update cycle server properties
   shell: |
-    sed -i 's/^webServerContextPath=.*$/webServerContextPath=\/cyclecloud/g;s/^webServerRedirectHttp=.*$/webServerRedirectHttp=false/g' /opt/cycle_server/config/cycle_server.properties
+    sed -i 's/^webServerContextPath=.*$/webServerContextPath=\{{cycle_webServerContextPath}}/g;s/^webServerRedirectHttp=.*$/webServerRedirectHttp=false/g' /opt/cycle_server/config/cycle_server.properties
     /opt/cycle_server/cycle_server restart
 
 - name: Configure Cycle Cloud portal host
@@ -105,7 +105,7 @@
   when: cyclecloud_version == "8.2.2-1902"
 
 - name: Configure CycleCloud CLI
-  command: '/usr/local/bin/cyclecloud initialize --force --batch --name ccportal --url=https://localhost:9443/cyclecloud --verify-ssl=false --username={{cc_admin_user}} --password="{{cc_password}}"'
+  command: '/usr/local/bin/cyclecloud initialize --force --batch --name ccportal --url=https://localhost:9443{{cycle_webServerContextPath}} --verify-ssl=false --username={{cc_admin_user}} --password="{{cc_password}}"'
   args:
     creates: /root/.cycle/config.ini
 

--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -66,7 +66,7 @@
     /tmp/cyclecloud-pbspro/initialize_default_queues.sh
     source /etc/profile.d/pbs.sh
     /tmp/cyclecloud-pbspro/install.sh  --venv /opt/cycle/pbspro/venv --install-venv
-    /tmp/cyclecloud-pbspro/generate_autoscale_json.sh  --install-dir /opt/cycle/pbspro --username {{ cc_admin }} --password "{{ cc_password }}" --url https://{{ccportal_name}}:9443/cyclecloud --cluster-name pbs1
+    /tmp/cyclecloud-pbspro/generate_autoscale_json.sh  --install-dir /opt/cycle/pbspro --username {{ cc_admin }} --password "{{ cc_password }}" --url https://{{ccportal_name}}:9443{{cycle_webServerContextPath}} --cluster-name pbs1
   args:
     chdir: /tmp/cyclecloud-pbspro
 

--- a/playbooks/roles/pbsserver/vars/main.yml
+++ b/playbooks/roles/pbsserver/vars/main.yml
@@ -1,2 +1,3 @@
 cyclecloud_pbspro: 2.0.19
 ccportal_name: "{{cyclecloud.name | default('ccportal')}}"
+cycle_webServerContextPath: "{{'/cyclecloud' if (cc_webserverpath | default('', true) | trim == '') else cc_webserverpath}}"

--- a/playbooks/roles/slurm/tasks/cyclecloud-server_2.7.x.yml
+++ b/playbooks/roles/slurm/tasks/cyclecloud-server_2.7.x.yml
@@ -152,7 +152,7 @@
 - name: install cc autoscale api
   shell: |
       /opt/cycle/jetpack/system/embedded/bin/pip install /opt/cycle/slurm/cyclecloud_api-8.1.0-py2.py3-none-any.whl  2>&1
-      /opt/cycle/slurm/cyclecloud_slurm.sh initialize --cluster-name slurm1 --username "{{ cc_admin }}" --password "{{ cc_password }}" --url https://{{cyclecloud.name | default("ccportal")}}:9443/cyclecloud
+      /opt/cycle/slurm/cyclecloud_slurm.sh initialize --cluster-name slurm1 --username "{{ cc_admin }}" --password "{{ cc_password }}" --url https://{{cyclecloud.name | default("ccportal")}}:9443{{cycle_webServerContextPath}}
   args:
     creates: /opt/cycle/jetpack/config/autoscale.json
 

--- a/playbooks/roles/slurm/templates/jetpack.ini.j2
+++ b/playbooks/roles/slurm/templates/jetpack.ini.j2
@@ -1,4 +1,4 @@
 [cycle_server]
-webserver=https://{{ cyclecloud.name | default('ccportal') }}:9443/cyclecloud
+webserver=https://{{ cyclecloud.name | default('ccportal') }}:9443{{cycle_webServerContextPath}}
 api_username={{admin_user}}
 api_password={{cc_password}}

--- a/playbooks/roles/slurm/templates/node.json.j2
+++ b/playbooks/roles/slurm/templates/node.json.j2
@@ -4,7 +4,7 @@
     {
         "config": 
         {
-            "web_server": "https://{{ cyclecloud.name | default('ccportal') }}:9443/cyclecloud",
+            "web_server": "https://{{ cyclecloud.name | default('ccportal') }}:9443{{cycle_webServerContextPath}}",
             "username": "{{admin_user}}",
             "password": "{{cc_password}}"
         },

--- a/playbooks/roles/slurm/vars/main.yml
+++ b/playbooks/roles/slurm/vars/main.yml
@@ -2,3 +2,4 @@ jetpack_home: /opt/cycle/jetpack
 # slurm uid/gid match cyclecloud-slurm cookbook values
 slurm_uid: 11100
 slurm_gid: 11100
+cycle_webServerContextPath: "{{'/cyclecloud' if (cc_webserverpath | default('', true) | trim == '') else cc_webserverpath}}"

--- a/playbooks/scheduler.yml
+++ b/playbooks/scheduler.yml
@@ -27,6 +27,7 @@
       cc_admin: '{{admin_user}}'
       cc_password: '{{password.stdout}}'
       cc_pbs_version: 1.4.0
+      cc_webserverpath: '{{cyclecloud.web_server_path | default("")}}'
     when: (queue_manager == "openpbs" or queue_manager is not defined) # default
 
   - include_role: 


### PR DESCRIPTION
- default is /cyclecloud to allow OOD proxy
Will open new scenario in which Cycle Cloud will be deployed alone
