### PR TITLE
chore: make idempotence check explicit for cc-slurm 3

### DIFF
--- a/playbooks/roles/slurm/tasks/cyclecloud-server_3.0.x.yml
+++ b/playbooks/roles/slurm/tasks/cyclecloud-server_3.0.x.yml
@@ -60,6 +60,9 @@
     set -e
     cd {{jetpack_home}}/system/bootstrap/azure-slurm-install
     ./install.sh --mode scheduler --bootstrap-config {{jetpack_home}}/config/node.json
+  args: 
+    creates: '/etc/azslurm-bins.installed'
+  
 
 # Install autoscaling for slurm. 
 # For reference see https://github.com/Azure/cyclecloud-slurm/blob/master/specs/scheduler/cluster-init/scripts/00-install.sh


### PR DESCRIPTION
The script responsible for installing slurm for cc-slurm 3.x has its own way of checking whether it already run successfully.

Making this explicit in the ansible role, so users who would like to run the script again (e.g. to update slurm) know which file to remove.