### PR TITLE
update RPM-GPG keys for AlmaLinux nodes

### DIFF
--- a/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
+++ b/playbooks/roles/cyclecloud_cluster/templates/azhop-slurm.txt.j2
@@ -30,7 +30,11 @@ set -x
 echo "cloud-init is removing slurm from the image ..." >> /tmp/cloud-init.txt
 date >> /tmp/cloud-init.txt
 case `grep "^ID=" /etc/os-release | cut -d= -f2 | xargs` in
-    centos|rhel|almalinux|rocky|oraclelinux)
+    almalinux)
+        rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+        yum remove munge* slurm* -y >> /tmp/cloud-init.txt
+        ;;
+    centos|rhel|rocky|oraclelinux)
         yum remove munge* slurm* -y >> /tmp/cloud-init.txt
         ;;
     ubuntu|debian)


### PR DESCRIPTION
RPM GPG keys have been rotated 
https://almalinux.org/blog/2023-12-20-almalinux-8-key-update/

close #1858 