### PR TITLE
Removed hardcoded Slurm cluster name

### DIFF
--- a/playbooks/nodearray_lookup.yml
+++ b/playbooks/nodearray_lookup.yml
@@ -15,7 +15,7 @@
 
     - name: Set SLURM cluster name
       set_fact:
-        cluster_name: "slurm1"
+        cluster_name: '{{ slurm.cluster_name | default("slurm1") }}'
       when: (queue_manager == "slurm")
 
     # Remove any forbidden characters from the username so we conform to the keyvaul secret name rules '^[0-9a-zA-Z-]+$'

--- a/playbooks/roles/cyclecloud_cluster/tasks/slurm.yml
+++ b/playbooks/roles/cyclecloud_cluster/tasks/slurm.yml
@@ -6,7 +6,7 @@
     dest: '{{project_root}}/azhop-slurm.txt'
 
 - name: Import Slurm Cluster
-  command: '/usr/local/bin/cyclecloud import_cluster slurm1 -f {{project_root}}/azhop-slurm.txt -c azhop-slurm --force'
+  command: '/usr/local/bin/cyclecloud import_cluster {{slurm_cluster_name}} -f {{project_root}}/azhop-slurm.txt -c azhop-slurm --force'
 
 - name: Start Slurm Cluster
-  command: '/usr/local/bin/cyclecloud start_cluster slurm1'
+  command: '/usr/local/bin/cyclecloud start_cluster {{slurm_cluster_name}}'

--- a/playbooks/roles/cyclecloud_cluster/vars/main.yml
+++ b/playbooks/roles/cyclecloud_cluster/vars/main.yml
@@ -13,3 +13,4 @@ munge_uid: 11101
 munge_gid: 11101
 cvmfs_eessi_enabled: false
 cyclecloud_openbps_release: 2.0.19
+slurm_cluster_name: '{{ slurm.cluster_name | default("slurm1") }}'


### PR DESCRIPTION
In the `cyclecloud_cluster` playbook the name of the Slurm cluster is hardcoded to `slurm1`. This causes the Slurm server installation to fail as the `slurm` playbook correctly uses the cluster name from the configuration file.