### PR TITLE
implements bug fix to ensure pbs dataservice starts up successfully

### DIFF
--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -143,6 +143,7 @@
   service: 
     name: postgresql
     state: started
+  when: ansible_distribution in ['CentOS', 'AlmaLinux']
 
 - name: start pbs-server 
   service: 
@@ -150,4 +151,4 @@
     state: started
 
 - name: check pbs connection
-  command: qstat
+  command: /opt/pbs/bin/qstat


### PR DESCRIPTION
close #1903 
Fix for issue 1903 to ensure scheduler playbook runs successfully with PBS and Ubuntu 20.04. 