### PR TITLE
removing the start of the postgresql 

### DIFF
--- a/playbooks/roles/pbsserver/tasks/main.yml
+++ b/playbooks/roles/pbsserver/tasks/main.yml
@@ -139,12 +139,6 @@
     name: pbs
     state: stopped
 
-- name: start postgresql 
-  service: 
-    name: postgresql
-    state: started
-  when: ansible_distribution in ['CentOS', 'AlmaLinux']
-
 - name: start pbs-server 
   service: 
     name: pbs


### PR DESCRIPTION
removing the start of the postgresql service to prevent conflicts with the startup of the pbs db