### PR TITLE
Bug Fixes

### DIFF
--- a/packer/azhop-ubuntu-20_04-desktop3d-ci.json
+++ b/packer/azhop-ubuntu-20_04-desktop3d-ci.json
@@ -39,7 +39,6 @@
             "inline": [
                 "chmod +x /tmp/*.sh",
                 "/tmp/linux-setup.sh || exit 1",
-                "/tmp/lustreclient.sh  || exit 1",
                 "/tmp/interactive-desktop-3d.sh || exit 1",
                 "/tmp/desktop-packages.sh || exit 1",
                 "/tmp/{{user `var_queue_manager`}}.sh || exit 1",

--- a/packer/azhop-ubuntu-20_04-v2-rdma-gpgpu-ci.json
+++ b/packer/azhop-ubuntu-20_04-v2-rdma-gpgpu-ci.json
@@ -41,7 +41,6 @@
                 "/tmp/linux-setup.sh || exit 1",
                 "/tmp/{{user `var_queue_manager`}}.sh || exit 1",
                 "/tmp/telegraf.sh || exit 1",
-                "/tmp/lustreclient.sh  || exit 1",
                 "/tmp/zz-compute-custom.sh || exit 1",
                 "echo ' This is the end '",
                 "rm -rf /tmp/*.sh",

--- a/packer/base-ubuntu-20_04-v2-rdma-gpgpu.json
+++ b/packer/base-ubuntu-20_04-v2-rdma-gpgpu.json
@@ -12,6 +12,7 @@
             "managed_image_name": "{{user `var_image`}}",
             "os_type": "Linux",
             "vm_size": "Standard_HB120rs_v3",
+            "os_disk_size_gb": "128",
             "managed_image_storage_account_type": "Premium_LRS",
             "ssh_pty": "true",
             "build_resource_group_name": "{{user `var_resource_group`}}",

--- a/packer/scripts/ubuntu/hpc_image.sh
+++ b/packer/scripts/ubuntu/hpc_image.sh
@@ -9,9 +9,9 @@ apt-get install -y git
 
 cd /mnt/
 
-git clone https://github.com/Azure/azhpc-images -b ubuntu-hpc-20231127
+git clone https://github.com/Azure/azhpc-images -b ubuntu-hpc-20241023
 
-sed -i 's/LUSTRE_VERSION=2.15.1-29-gbae0abe/LUSTRE_VERSION=2.15.4-42-gd6d405d/g' ./azhpc-images/ubuntu/common/install_lustre_client.sh
+sed -i 's/azcopyvnext.azureedge/azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd/g' ./azhpc-images/common/install_azcopy.sh
 
 cd ./azhpc-images/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc
 

--- a/playbooks/roles/cyclecloud/tasks/main.yml
+++ b/playbooks/roles/cyclecloud/tasks/main.yml
@@ -37,6 +37,7 @@
     CS_ROOT=/opt/cycle_server
     unzip $CS_ROOT/tools/cyclecloud-cli.zip
     cd cyclecloud-cli-installer
+    sed -i 's/azcopyvnext.azureedge/azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd/g' ./install.py
     ./install.sh --system -y -v
     cd $mydir
     # Update properties


### PR DESCRIPTION
Updating to the latest branch of hpc-images to ensure successful execution of lustre install during image building process. 

Adding a sed command due to updated path for azure-cli install. This will ensure that the cyclecloud cli install and the image building process completes successfully. 

Increasing default OS size for HPC images to make sure the image has enough space to install all tools and libraries. 

Removing separate script to install lustre since it is done by the hpc-images scripts.  